### PR TITLE
feat:  Build Payment History Table (Creator Earnings) 

### DIFF
--- a/src/app/dashboard/earnings/page.tsx
+++ b/src/app/dashboard/earnings/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { Percent } from "lucide-react"
 import { cn } from "@/lib/utils"
+import EarningsTable from "@/components/dashboard/EarningsTable"
 
 const EARNINGS_DATA = {
   "All-Time": "$1,500",
@@ -49,11 +50,9 @@ export default function EarningsPage() {
         </div>
       </div>
 
+      {/* Payment History Table */}
       <div className="mt-12">
-        <p className="text-slate-500 text-sm">Recent History</p>
-        <div className="mt-4 border-t border-[#1C1C1E] pt-4">
-          <p className="text-slate-600">No recent transactions found.</p>
-        </div>
+        <EarningsTable />
       </div>
     </div>
   )

--- a/src/components/dashboard/EarningsTable.tsx
+++ b/src/components/dashboard/EarningsTable.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { useState } from "react"
+import { Copy, Check } from "lucide-react"
+import { cn } from "@/components/ui/utils"
+
+export interface EarningTransaction {
+  sn: number
+  transactionId: string
+  amount: string
+  date: string
+}
+
+interface EarningsTableProps {
+  transactions?: EarningTransaction[]
+  className?: string
+}
+
+const mockTransactions: EarningTransaction[] = [
+  {
+    sn: 1,
+    transactionId: "0xe46d0b1039a8f97df2800a4c12b8e3a7f6d9e1b0",
+    amount: "$15",
+    date: "12th Jan, 2025",
+  },
+  {
+    sn: 2,
+    transactionId: "0xe46d0b1039a8f97df2800a4c12b8e3a7f6d9e1b0",
+    amount: "$15",
+    date: "12th Jan, 2025",
+  },
+  {
+    sn: 3,
+    transactionId: "0xe46d0b1039a8f97df2800a4c12b8e3a7f6d9e1b0",
+    amount: "$15",
+    date: "12th Jan, 2025",
+  },
+  {
+    sn: 4,
+    transactionId: "0xa91f3c7e2d4b08165ef3920dc7a8b5e10f6d42c3",
+    amount: "$25",
+    date: "5th Feb, 2025",
+  },
+  {
+    sn: 5,
+    transactionId: "0xb72e8d5f1a3c964027de481bc90a6f7e23d58b14",
+    amount: "$40",
+    date: "18th Feb, 2025",
+  },
+]
+
+function truncateId(id: string): string {
+  if (id.length <= 24) return id
+  return id.slice(0, 24) + "…"
+}
+
+export default function EarningsTable({
+  transactions = mockTransactions,
+  className,
+}: EarningsTableProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const handleCopy = async (id: string) => {
+    try {
+      await navigator.clipboard.writeText(id)
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 1500)
+    } catch {
+      // Fallback for environments without clipboard API
+      const textarea = document.createElement("textarea")
+      textarea.value = id
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand("copy")
+      document.body.removeChild(textarea)
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 1500)
+    }
+  }
+
+  return (
+    <div className={cn("flex flex-col items-start gap-3 w-full", className)}>
+      {/* Title */}
+      <h2 className="text-lg font-semibold text-white">Payment History</h2>
+
+      {/* Mobile: Card Layout */}
+      <div className="block md:hidden w-full space-y-4">
+        {transactions.map((tx) => (
+          <div
+            key={`${tx.transactionId}-${tx.sn}`}
+            className="bg-[#110719] rounded-lg border border-white/10 p-4 space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-gray-300 uppercase">SN</span>
+              <span className="text-sm text-gray-400">{tx.sn}</span>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-semibold text-gray-300 uppercase">Transaction ID</span>
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-sm text-gray-400 font-mono truncate">
+                  {truncateId(tx.transactionId)}
+                </span>
+                <button
+                  onClick={() => handleCopy(tx.transactionId)}
+                  className="flex-shrink-0 text-gray-400 hover:text-white transition-colors"
+                  aria-label={`Copy transaction ID ${tx.transactionId}`}
+                >
+                  {copiedId === tx.transactionId ? (
+                    <Check className="w-4 h-4 text-green-400" />
+                  ) : (
+                    <Copy className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-gray-300 uppercase">Amount</span>
+              <span className="text-sm text-gray-400">{tx.amount}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-gray-300 uppercase">Date</span>
+              <span className="text-sm text-gray-400">{tx.date}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop: Table Layout */}
+      <div className="hidden md:block overflow-x-auto w-full">
+        <div className="inline-block min-w-full align-middle">
+          <div className="overflow-hidden rounded-lg border border-white/10">
+            <table className="min-w-full divide-y divide-white/10">
+              <thead className="bg-white/5">
+                <tr>
+                  <th
+                    scope="col"
+                    className="py-3 px-4 text-left text-xs font-semibold text-gray-300 uppercase tracking-wider whitespace-nowrap"
+                  >
+                    SN
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-3 px-4 text-left text-xs font-semibold text-gray-300 uppercase tracking-wider whitespace-nowrap"
+                  >
+                    Transaction ID
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-3 px-4 text-left text-xs font-semibold text-gray-300 uppercase tracking-wider whitespace-nowrap"
+                  >
+                    Amount
+                  </th>
+                  <th
+                    scope="col"
+                    className="py-3 px-4 text-left text-xs font-semibold text-gray-300 uppercase tracking-wider whitespace-nowrap"
+                  >
+                    Date
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-[#110719] divide-y divide-white/5">
+                {transactions.map((tx) => (
+                  <tr
+                    key={`${tx.transactionId}-${tx.sn}`}
+                    className="transition-colors hover:bg-white/5"
+                  >
+                    <td className="py-4 px-4 whitespace-nowrap text-sm text-gray-400">
+                      {tx.sn}
+                    </td>
+                    <td className="py-4 px-4 whitespace-nowrap text-sm text-gray-400">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono">{truncateId(tx.transactionId)}</span>
+                        <button
+                          onClick={() => handleCopy(tx.transactionId)}
+                          className="text-gray-400 hover:text-white transition-colors"
+                          aria-label={`Copy transaction ID ${tx.transactionId}`}
+                        >
+                          {copiedId === tx.transactionId ? (
+                            <Check className="w-4 h-4 text-green-400" />
+                          ) : (
+                            <Copy className="w-4 h-4" />
+                          )}
+                        </button>
+                      </div>
+                    </td>
+                    <td className="py-4 px-4 whitespace-nowrap text-sm text-gray-400">
+                      {tx.amount}
+                    </td>
+                    <td className="py-4 px-4 whitespace-nowrap text-sm text-gray-400">
+                      {tx.date}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

Implements the Payment History table component for the Creator Earnings dashboard page, displaying transaction records with truncated IDs, copy-to-clipboard functionality, and responsive behavior.

Closes #67, #69

---

### Changes

- **New** [src/components/dashboard/EarningsTable.tsx](cci:7://file:///home/jahrulez/Desktop/oss/jahrulez/SkillSphere-Dapp/src/components/dashboard/EarningsTable.tsx:0:0-0:0) — Reusable component with:
  - Semantic `<table>` structure with 4 columns: SN, Transaction ID, Amount, Date
  - Truncated transaction IDs with a copy icon (clipboard API with fallback)
  - Visual feedback (checkmark) on successful copy
  - 5 mock rows for UI demonstration
  - Responsive card-based layout on mobile (`<md` breakpoint)
- **Modified** [src/app/dashboard/earnings/page.tsx](cci:7://file:///home/jahrulez/Desktop/oss/jahrulez/SkillSphere-Dapp/src/app/dashboard/earnings/page.tsx:0:0-0:0) — Replaced the "No recent transactions" placeholder with the new [EarningsTable](cci:1://file:///home/jahrulez/Desktop/oss/jahrulez/SkillSphere-Dapp/src/components/dashboard/EarningsTable.tsx:56:0-200:1) component

### Visual Evidence

https://github.com/user-attachments/assets/ee6ce2ad-b93e-4a1c-84d6-3abbeafd9093



### Acceptance Criteria

- [x] Table matches Figma layout
- [x] Transaction IDs truncated with ellipsis
- [x] Copy icon positioned correctly beside Transaction ID
- [x] Amount displayed with `$` currency symbol
- [x] Proper date formatting (e.g. `12th Jan, 2025`)
- [x] Responsive scrolling/card layout on small screens