### PR TITLE
ci: add Soroban contract build workflow

### DIFF
--- a/.github/workflows/soroban-contract.yml
+++ b/.github/workflows/soroban-contract.yml
@@ -1,0 +1,45 @@
+name: Soroban Contract
+
+on:
+  pull_request:
+    paths:
+      - "contracts/**"
+      - ".github/workflows/soroban-contract.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/**"
+      - ".github/workflows/soroban-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test Soroban contract
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry and build output
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts
+
+      - name: Run contract tests
+        run: cargo test --locked
+
+      - name: Build optimized contract WASM
+        run: cargo build --release --locked --target wasm32-unknown-unknown

--- a/.github/workflows/soroban-contract.yml
+++ b/.github/workflows/soroban-contract.yml
@@ -38,8 +38,18 @@ jobs:
         with:
           workspaces: contracts
 
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+
       - name: Run contract tests
         run: cargo test --locked
 
       - name: Build optimized contract WASM
         run: cargo build --release --locked --target wasm32-unknown-unknown
+
+      - name: Upload built WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: soroban-contract-wasm
+          path: contracts/target/wasm32-unknown-unknown/release/*.wasm
+          if-no-files-found: error

--- a/.github/workflows/soroban-contract.yml
+++ b/.github/workflows/soroban-contract.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
           components: clippy, rustfmt
 
       - name: Cache Cargo registry and build output
@@ -55,5 +55,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: soroban-contract-wasm
-          path: contracts/target/wasm32-unknown-unknown/release/*.wasm
+          path: contracts/target/wasm32v1-none/release/*.wasm
           if-no-files-found: error

--- a/.github/workflows/soroban-contract.yml
+++ b/.github/workflows/soroban-contract.yml
@@ -32,20 +32,24 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy, rustfmt
 
       - name: Cache Cargo registry and build output
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: contracts
+          workspaces: contracts -> target
 
-      - name: Check Rust formatting
-        run: cargo fmt --all -- --check
+      - name: Install Soroban CLI
+        run: cargo install --locked soroban-cli
 
       - name: Run contract tests
         run: cargo test --locked
 
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Build optimized contract WASM
-        run: cargo build --release --locked --target wasm32-unknown-unknown
+        run: soroban contract build
 
       - name: Upload built WASM artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Adds a no-secret GitHub Actions workflow for the Soroban contract under `contracts/`.
- Runs on PR/push changes to `contracts/**` and supports manual dispatch.
- Installs stable Rust with the `wasm32-unknown-unknown` target, caches Cargo, runs `cargo test --locked`, and builds optimized WASM.

Fixes #172.

## Test plan
- `git diff --check`
- Local workflow-text assertions for trigger paths, Rust setup, wasm target, test command, and build command.

Note: local full `cargo test --locked` could not run on this worker because its Cargo is 1.75 and the repo lockfile is v4. The workflow uses current stable Rust, which should handle the lockfile format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow for Soroban contracts that runs on pull requests, main pushes, and via manual trigger.
  * Sets up the Rust toolchain, runs tests and linters, builds optimized WebAssembly contract artifacts, and uploads the resulting release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->