### PR TITLE
feat: build course video player UI with play button, side controls, a…

### DIFF
--- a/src/app/dashboard/courses/[id]/page.tsx
+++ b/src/app/dashboard/courses/[id]/page.tsx
@@ -6,9 +6,21 @@ import SummaryTabContent from "@/components/dashboard/SummaryTabContent";
 import ResourcesTabContent from "@/components/dashboard/ResourcesTabContent";
 import TaskTabContent from "@/components/dashboard/TaskTabContent";
 import CourseContentTrackerSidebar from "@/components/dashboard/CourseContentTrackerSidebar";
+import CourseVideoPlayer from "@/components/dashboard/CourseVideoPlayer";
+import { Checkbox } from "@/components/ui/Checkbox";
 import image1 from "../../../../../public/Image (1).png";
 
 type TabId = "overview" | "resources" | "tasks" | "summary";
+
+const LESSONS = [
+  { id: 1, title: "Lesson 1: Intro to Digital Technology", duration: "5 min" },
+  { id: 2, title: "Lesson 2: Blockchain Basics", duration: "5 min" },
+  { id: 3, title: "Lesson 3: Smart Contracts", duration: "5 min" },
+  { id: 4, title: "Lesson 4: DeFi Fundamentals", duration: "5 min" },
+  { id: 5, title: "Lesson 5: Web3 Wallets", duration: "5 min" },
+  { id: 6, title: "Lesson 6: dApp Development", duration: "5 min" },
+  { id: 7, title: "Lesson 7: Token Standards", duration: "5 min" },
+];
 
 interface Params {
   id: string;
@@ -102,6 +114,8 @@ const COURSE_DATA: Record<
 export default function CourseDetailsPage({ params }: { params: Params }) {
   const courseData = COURSE_DATA[params.id];
   const [activeTab, setActiveTab] = useState<TabId>("overview");
+  const [currentLesson, setCurrentLesson] = useState(0);
+  const [completed, setCompleted] = useState(false);
 
   if (!courseData) {
     return (
@@ -111,26 +125,49 @@ export default function CourseDetailsPage({ params }: { params: Params }) {
     );
   }
 
+  const handlePrevious = () =>
+    setCurrentLesson((prev) => Math.max(0, prev - 1));
+  const handleNext = () =>
+    setCurrentLesson((prev) => Math.min(LESSONS.length - 1, prev + 1));
+
   return (
     <div className="space-y-6 pb-12">
-      <div className="space-y-4">
-        <div className="relative w-full h-64 rounded-lg overflow-hidden bg-gray-900">
-          <img
-            src={courseData.image}
-            alt={courseData.title}
-            className="w-full h-full object-cover"
-          />
-        </div>
-        <h1 className="text-2xl font-bold text-white">{courseData.title}</h1>
+      {/* Breadcrumb */}
+      <div className="bg-[#1A1520] border border-[#1D1D1C] rounded-xl px-5 py-3 flex items-center gap-3 text-sm">
+        <span className="text-white/60 truncate">{courseData.title}</span>
+        <span className="text-white/30 shrink-0">|</span>
+        <span className="text-white font-medium truncate">
+          {LESSONS[currentLesson].title}
+        </span>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2 space-y-6">
+        {/* Left: video + tabs */}
+        <div className="lg:col-span-2 space-y-4">
+          <CourseVideoPlayer
+            thumbnailSrc={courseData.image}
+            thumbnailAlt={LESSONS[currentLesson].title}
+            onPrevious={handlePrevious}
+            onNext={handleNext}
+          />
+
+          {/* Completed checkbox */}
+          <label className="flex items-center gap-2 cursor-pointer w-fit">
+            <Checkbox
+              checked={completed}
+              onCheckedChange={(val) => setCompleted(Boolean(val))}
+              shape="square"
+              className="border-white/30 data-[state=checked]:bg-purple-600 data-[state=checked]:border-purple-600"
+            />
+            <span className="text-sm text-white/80 select-none">Completed</span>
+          </label>
+
+          {/* Tabs */}
           <div className="flex gap-2 border-b border-[#1D1D1C] overflow-x-auto">
             {[
               { id: "overview" as const, label: "Overview" },
               { id: "resources" as const, label: "Resources" },
-              { id: "tasks" as const, label: "Tasks" },
+              { id: "tasks" as const, label: "Task" },
               { id: "summary" as const, label: "Summary" },
             ].map((tab) => (
               <button
@@ -167,8 +204,20 @@ export default function CourseDetailsPage({ params }: { params: Params }) {
           </div>
         </div>
 
+        {/* Right: tutor + content tracker */}
         <div className="lg:col-span-1">
-          <CourseContentTrackerSidebar />
+          <CourseContentTrackerSidebar
+            lessons={LESSONS.map((l) => ({
+              id: l.id,
+              title: l.title,
+              duration: l.duration,
+            }))}
+            tutorInfo={{
+              name: "Satoshi Nakamoto",
+              role: "Front-End Developer",
+              avatar: "/avatarPlaceholder1.jpg",
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/components/dashboard/CourseVideoPlayer.tsx
+++ b/src/components/dashboard/CourseVideoPlayer.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React, { useState } from "react";
+import { Play, SkipBack, SkipForward } from "lucide-react";
+
+interface CourseVideoPlayerProps {
+  thumbnailSrc: string;
+  thumbnailAlt?: string;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  onPlay?: () => void;
+}
+
+export default function CourseVideoPlayer({
+  thumbnailSrc,
+  thumbnailAlt = "Course video thumbnail",
+  onPrevious,
+  onNext,
+  onPlay,
+}: CourseVideoPlayerProps) {
+  const [isPlayHovered, setIsPlayHovered] = useState(false);
+
+  return (
+    <div className="relative w-full aspect-video rounded-xl overflow-hidden bg-[#0B0113]">
+      {/* Thumbnail */}
+      <img
+        src={thumbnailSrc}
+        alt={thumbnailAlt}
+        className="w-full h-full object-cover"
+      />
+
+      {/* Dark overlay */}
+      <div className="absolute inset-0 bg-black/40" />
+
+      {/* Side nav: Previous */}
+      <button
+        onClick={onPrevious}
+        className="absolute left-4 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 rounded-full bg-black/50 border border-white/10 text-white hover:bg-black/70 hover:border-white/30 transition-all duration-200 backdrop-blur-sm"
+        aria-label="Previous lesson"
+      >
+        <SkipBack size={18} />
+      </button>
+
+      {/* Center play button */}
+      <button
+        onClick={onPlay}
+        onMouseEnter={() => setIsPlayHovered(true)}
+        onMouseLeave={() => setIsPlayHovered(false)}
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center transition-all duration-200"
+        aria-label="Play video"
+      >
+        <span
+          className={`flex items-center justify-center w-16 h-16 rounded-full border-2 border-white bg-white/10 backdrop-blur-sm transition-all duration-200 ${
+            isPlayHovered
+              ? "bg-white/25 scale-110 shadow-[0_0_32px_rgba(255,255,255,0.25)]"
+              : ""
+          }`}
+        >
+          <Play
+            size={28}
+            className="text-white fill-white translate-x-0.5"
+          />
+        </span>
+      </button>
+
+      {/* Side nav: Next */}
+      <button
+        onClick={onNext}
+        className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 rounded-full bg-black/50 border border-white/10 text-white hover:bg-black/70 hover:border-white/30 transition-all duration-200 backdrop-blur-sm"
+        aria-label="Next lesson"
+      >
+        <SkipForward size={18} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #82

- Added `CourseVideoPlayer` component with thumbnail, centered play button overlay, and previous/next side controls (UI only)
- Play button scales and glows on hover (bonus requirement)
- Integrated video player into the course class screen (`/dashboard/courses/[id]`) replacing the static image
- Added breadcrumb bar showing course title and active lesson name
- Added `Completed` checkbox below the player wired to local state
- Lesson navigation updates the breadcrumb title on prev/next click

## Screenshots

<!-- Attach screenshot of http://localhost:3000/dashboard/courses/1 here -->

## Test

- [x] Visit `/dashboard/courses/1` — video thumbnail and play button render correctly
- [x] Play button is centered over the thumbnail
- [x] Hovering the play button scales it up and adds a white glow
- [x] Clicking `⏭` / `⏮` updates the lesson title in the breadcrumb
- [x] Completed checkbox toggles purple when clicked
- [x] Layout is responsive — sidebar stacks below video on mobile widths

## mobile screen
<img width="1078" height="797" alt="Screenshot 2026-04-29 at 9 52 58 AM" src="https://github.com/user-attachments/assets/d46e54b4-0bf9-4ae5-b184-881342bf58bf" />

## desktop screen
<img width="1754" height="919" alt="Screenshot 2026-04-29 at 9 53 23 AM" src="https://github.com/user-attachments/assets/81755b7e-d230-4096-ba15-4da40f6bf9f0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lesson-driven navigation on course pages with previous/next controls.
  * New video player interface with play button and lesson navigation.
  * Per-lesson "Completed" checkbox to track progress.
  * Breadcrumbs now show the current lesson context.
  * Tab label updated from “Tasks” to “Task”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->