### PR TITLE
feat: implement course learning header section for class screen

### DIFF
--- a/src/app/dashboard/courses/[id]/page.tsx
+++ b/src/app/dashboard/courses/[id]/page.tsx
@@ -6,6 +6,7 @@ import SummaryTabContent from "@/components/dashboard/SummaryTabContent";
 import ResourcesTabContent from "@/components/dashboard/ResourcesTabContent";
 import TaskTabContent from "@/components/dashboard/TaskTabContent";
 import CourseContentTrackerSidebar from "@/components/dashboard/CourseContentTrackerSidebar";
+import CourseLearningHeader from "@/components/dashboard/CourseLearningHeader";
 import image1 from "../../../../../public/Image (1).png";
 
 type TabId = "overview" | "resources" | "tasks" | "summary";
@@ -18,6 +19,7 @@ const COURSE_DATA: Record<
   string,
   {
     title: string;
+    currentLesson: string;
     image: string;
     overview: string;
     learningPoints: string[];
@@ -29,6 +31,7 @@ const COURSE_DATA: Record<
 > = {
   "1": {
     title: "Become a Web3 Developer: A beginners approach",
+    currentLesson: "Intro to Digital Technology",
     image: image1.src,
     overview:
       "This comprehensive course introduces you to Web3 development fundamentals. Learn blockchain concepts, smart contracts, and decentralized application development from industry experts.",
@@ -64,6 +67,7 @@ const COURSE_DATA: Record<
   },
   "2": {
     title: "Design made simple",
+    currentLesson: "Fundamentals of Visual Design",
     image: image1.src,
     overview:
       "A complete guide to modern interface design principles and practices. Learn how to create beautiful, functional, and user-centered digital experiences.",
@@ -113,20 +117,22 @@ export default function CourseDetailsPage({ params }: { params: Params }) {
 
   return (
     <div className="space-y-6 pb-12">
-      <div className="space-y-4">
-        <div className="relative w-full h-64 rounded-lg overflow-hidden bg-gray-900">
-          <img
-            src={courseData.image}
-            alt={courseData.title}
-            className="w-full h-full object-cover"
-          />
-        </div>
-        <h1 className="text-2xl font-bold text-white">{courseData.title}</h1>
-      </div>
-
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2 space-y-6">
-          <div className="flex gap-2 border-b border-[#1D1D1C] overflow-x-auto">
+        <div className="lg:col-span-2 space-y-4">
+          <CourseLearningHeader
+            courseTitle={courseData.title}
+            currentLesson={courseData.currentLesson}
+          />
+
+          <div className="relative w-full h-64 rounded-lg overflow-hidden bg-gray-900">
+            <img
+              src={courseData.image}
+              alt={courseData.title}
+              className="w-full h-full object-cover"
+            />
+          </div>
+
+          <div className="flex gap-2 border-b border-[#1D1D1C] overflow-x-auto mt-2">
             {[
               { id: "overview" as const, label: "Overview" },
               { id: "resources" as const, label: "Resources" },

--- a/src/components/dashboard/CourseLearningHeader.tsx
+++ b/src/components/dashboard/CourseLearningHeader.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React from "react";
+
+interface CourseLearningHeaderProps {
+  courseTitle: string;
+  currentLesson: string;
+}
+
+export default function CourseLearningHeader({
+  courseTitle,
+  currentLesson,
+}: CourseLearningHeaderProps) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-0 px-4 py-2.5 bg-[#1A1520] border border-[#1D1D1C] rounded-xl overflow-hidden">
+      <span className="text-sm text-white/50 truncate min-w-0">
+        {courseTitle}
+      </span>
+      <span className="hidden sm:block mx-2.5 text-white/30 flex-shrink-0 select-none">
+        |
+      </span>
+      <span className="text-sm font-semibold text-white truncate min-w-0">
+        {currentLesson}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Created `CourseLearningHeader` component displaying course title and current lesson separated by a `|` divider
- Integrated the header into the course class screen (`/dashboard/courses/[id]`), placed above the video player inside the left content column
- Added `currentLesson` field to `COURSE_DATA` for each course
- Removed the old standalone `h1` title and moved the video/image inside the grid's left column to match Figma layout

## Changes

- `src/components/dashboard/CourseLearningHeader.tsx` — new reusable component
- `src/app/dashboard/courses/[id]/page.tsx` — integrated header, restructured layout to match Figma

## Responsive behaviour

| Breakpoint | Layout |
|---|---|
| Mobile (`< sm`) | Title and lesson stack vertically |
| SM+ | Horizontal row: `Course Title \| Current Lesson` |

## Acceptance Criteria

- [x] Course title renders correctly
- [x] Current lesson (subtitle) renders correctly
- [x] Content aligned horizontally with separator
- [x] Matches Figma layout structure
- [x] Responsive on smaller screens

## Closes 
- close #81

## Screenshot

<img width="1731" height="260" alt="Screenshot 2026-04-29 at 11 12 56" src="https://github.com/user-attachments/assets/9fd07a3d-5f8e-4d3d-9a9d-a38d2dd22b49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Course pages now display the current lesson alongside the course title in a dedicated header section for improved lesson tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->