### PR TITLE
feat(contracts): heartbeat, dispute evidence, platform stats, gas sponsorship docs

### DIFF
--- a/contracts/GAS_SPONSORSHIP.md
+++ b/contracts/GAS_SPONSORSHIP.md
@@ -1,0 +1,93 @@
+# Soroban Fee Sponsorship — SkillSphere (#201)
+
+Stellar lets one account pay another account's transaction fees via
+`SponsoredTransaction` / `pay_and_invoke` patterns. SkillSphere's
+public entry points are designed so a sponsor (e.g. an onboarding
+campaign, an employer onboarding their experts, or a referral program)
+can cover gas for first-time users without changing the user's
+authentication semantics.
+
+## How it works on Stellar
+
+A Soroban transaction has two distinct accounts:
+
+| Role         | Pays the fee?              | Required signature |
+| ------------ | -------------------------- | ------------------ |
+| **Fee source** | yes                        | yes                |
+| **Source / invoker** | no                  | yes, on `invoke_host_function` |
+
+When the two are different, the transaction is a *sponsored* invocation.
+The sponsor's keypair signs the fee-bump envelope and the invoker
+(seeker / expert / admin) signs the inner `InvokeHostFunctionOp`.
+
+## How SkillSphere entry points stay sponsor-compatible
+
+All public entry points that touch funds or change protocol state call
+`<address>.require_auth()` against the **invoker** address — never
+against `env.current_contract_address()` and never against an implicit
+"transaction source". Concrete examples:
+
+- `register_expert(expert, ..)` requires `expert.require_auth()`.
+- `start_session(seeker, expert, ..)` requires `seeker.require_auth()`.
+- `heartbeat(expert)` requires `expert.require_auth()` (#199).
+- `flag_dispute(session_id, seeker, ..)` requires `seeker.require_auth()`.
+- `add_dispute_evidence(caller, ..)` requires `caller.require_auth()` (#198).
+- `settle_session(session_id)` requires `session.expert.require_auth()`.
+
+Because the invoker is always an *explicit* `Address` argument, the
+sponsor can be any account — including one that has never interacted
+with the contract before — and the call still succeeds as long as the
+invoker signs.
+
+## Sponsoring an `start_session` from a campaign account
+
+Pseudocode (TypeScript, `@stellar/stellar-sdk`):
+
+```ts
+const tx = new TransactionBuilder(sponsorSource, {fee: BASE_FEE, networkPassphrase})
+  .addOperation(Operation.invokeHostFunction({
+    func: xdr.HostFunction.hostFunctionTypeInvokeContract(/* start_session args */),
+    auth: [
+      // The seeker authorises the contract call.
+      seekerAuth,
+    ],
+  }))
+  .setTimeout(30)
+  .build();
+
+// Sponsor pays the fee:
+tx.sign(sponsorKey);
+// Seeker authorises the invocation:
+tx.sign(seekerKey);
+```
+
+The contract sees `seeker.require_auth()` succeed because the seeker's
+auth entry is in `auth[]`; the fee comes from `sponsorSource`'s XLM
+balance.
+
+## Things sponsors should know
+
+1. **Fee source must hold XLM.** Contract calls cost in XLM; SkillSphere
+   does not subsidise XLM gas itself.
+2. **Token approvals are the user's job.** If the entry point transfers
+   a token from the user (e.g. `start_session` calls
+   `token.transfer(seeker, contract, amount)`), the seeker still needs
+   to hold and authorise that token transfer. The sponsor only covers
+   the XLM fee, not the funded amount.
+3. **No state lives on the sponsor account.** Sponsors are interchangeable
+   — the contract attributes every effect to the invoker, never to the
+   fee source.
+4. **Heartbeat (#199) and dispute-evidence (#198) calls are cheap and
+   sponsor-friendly.** Both are zero-token, single-storage-write
+   operations — typical use case: an onboarding pipeline that ticks
+   `heartbeat()` for newly-onboarded experts using a single sponsor
+   key.
+
+## What does NOT need changing
+
+The acceptance criteria for #201 asked us to confirm the entry points
+are "compatible with Soroban fee-sponsorship patterns". The audit above
+confirms they already are — every public entry point takes the
+authorising party as an explicit `Address` and calls
+`require_auth()` on it. No contract-side change is required to enable
+sponsorship; only client-side transaction-builder code differs.

--- a/contracts/src/errors.rs
+++ b/contracts/src/errors.rs
@@ -37,4 +37,6 @@ pub enum Error {
     InvalidOracleSignature = 31,
     InvalidSessionState = 32,
     InsufficientBalance = 33,
+    ExpertOffline = 34,
+    DisputeAlreadyResolved = 35,
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -36,6 +36,14 @@ const REFERRAL_COMMISSION_BPS: u32 = 500; // 5% of platform fee for referrer
 const REFERRAL_SESSION_LIMIT: u32 = 10; // Referral commission applies to first X sessions
 const RATING_SCALE_MIN: u32 = 1;
 const RATING_SCALE_MAX: u32 = 5;
+// Expert availability heartbeat window (#199): an expert who has called
+// `heartbeat()` more than this many seconds ago is treated as offline
+// for the purposes of `start_session`.
+const HEARTBEAT_VALIDITY_WINDOW: u64 = 60 * 60; // 1 hour
+// PlatformStats event emission cadence (#200): emit a rolled-up stats
+// event every Nth settled session so off-chain indexers can track total
+// volume + session count without re-scanning every single event.
+const PLATFORM_STATS_EMIT_INTERVAL: u64 = 100;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -62,6 +70,14 @@ pub enum DataKey {
     ReferralSessionCount(Address),
     TrustedOracle(Address),
     ExpertVerificationStatus(Address),
+    // #199: last `heartbeat()` timestamp (seconds since unix epoch).
+    // Stored separately from ExpertProfile so adding the field is
+    // backward-compatible with existing on-chain profiles — no
+    // migration needed.
+    ExpertLastHeartbeat(Address),
+    // #200: running counters used by the rolled-up PlatformStats event.
+    TotalVolumeSettled,
+    TotalSessionsSettled,
 }
 
 #[contracttype]
@@ -225,6 +241,105 @@ impl SkillSphereContract {
         env.storage()
             .persistent()
             .set(&DataKey::ExpertProfile(expert), &profile);
+    }
+
+    /// Refresh the expert's availability heartbeat (#199).
+    ///
+    /// Stamps `ExpertLastHeartbeat(expert)` with the current ledger
+    /// timestamp. `start_session` rejects experts whose last heartbeat
+    /// is older than `HEARTBEAT_VALIDITY_WINDOW` (1 hour). Experts who
+    /// have never called `heartbeat` retain the legacy
+    /// `availability_status`-only semantics so existing flows keep
+    /// working until they opt in.
+    pub fn heartbeat(env: Env, expert: Address) -> Result<(), Error> {
+        expert.require_auth();
+        let profile = Self::expert_profile(&env, expert.clone());
+        if profile.rate_per_second == 0 {
+            return Err(Error::ExpertNotRegistered);
+        }
+        let now = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&DataKey::ExpertLastHeartbeat(expert.clone()), &now);
+        env.events()
+            .publish((symbol_short!("hb"),), (expert, now));
+        Ok(())
+    }
+
+    /// Read the last `heartbeat()` timestamp for an expert (#199).
+    /// Returns `0` if the expert has never called heartbeat.
+    pub fn last_heartbeat(env: Env, expert: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExpertLastHeartbeat(expert))
+            .unwrap_or(0u64)
+    }
+
+    /// Append fresh evidence to an active dispute (#198).
+    ///
+    /// Only callable while the dispute is unresolved and only by the
+    /// session's seeker, expert, or the contract admin. Replaces
+    /// `Dispute.evidence_cid` with the new CID — latest evidence wins
+    /// from the arbitrator's point of view. The previous CID is still
+    /// recoverable via the historical `evidence_added` events.
+    pub fn add_dispute_evidence(
+        env: Env,
+        caller: Address,
+        session_id: u64,
+        cid: String,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+
+        if !Self::is_valid_ipfs_cid(&cid) {
+            return Err(Error::InvalidCid);
+        }
+
+        let mut dispute: Dispute = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Dispute(session_id))
+            .ok_or(Error::DisputeNotFound)?;
+
+        if dispute.resolved {
+            return Err(Error::DisputeAlreadyResolved);
+        }
+
+        let session = Self::get_session_or_error(&env, session_id)?;
+        if !matches!(session.status, SessionStatus::Disputed) {
+            return Err(Error::InvalidSessionState);
+        }
+
+        let admin = Self::get_admin_address(&env)?;
+        if caller != session.seeker && caller != session.expert && caller != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        dispute.evidence_cid = cid.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(session_id), &dispute);
+
+        env.events().publish(
+            (symbol_short!("dispute"), symbol_short!("evidence")),
+            (session_id, caller, cid),
+        );
+        Ok(())
+    }
+
+    /// Read the rolled-up PlatformStats counters (#200).
+    /// Returns `(total_sessions_settled, total_volume_settled)`.
+    pub fn platform_stats(env: Env) -> (u64, i128) {
+        let sessions: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSessionsSettled)
+            .unwrap_or(0u64);
+        let volume: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalVolumeSettled)
+            .unwrap_or(0i128);
+        (sessions, volume)
     }
 
     /// Updates the encrypted notes hash for a specific session.
@@ -749,6 +864,23 @@ impl SkillSphereContract {
         }
         if !profile.availability_status {
             panic_with_error!(&env, Error::ExpertUnavailable);
+        }
+
+        // #199: heartbeat freshness check.
+        // Backward-compat: experts who have never called `heartbeat()`
+        // (no LastHeartbeat key) keep the legacy "online via
+        // availability_status only" semantics so existing flows don't
+        // break. Once an expert has called heartbeat at least once, the
+        // 1-hour window is enforced on every new session.
+        if let Some(last_hb) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&DataKey::ExpertLastHeartbeat(expert.clone()))
+        {
+            let now_secs = env.ledger().timestamp();
+            if now_secs.saturating_sub(last_hb) > HEARTBEAT_VALIDITY_WINDOW {
+                panic_with_error!(&env, Error::ExpertOffline);
+            }
         }
 
         if profile.reputation < min_reputation {
@@ -1292,6 +1424,40 @@ impl SkillSphereContract {
             .set(&DataKey::Session(session.id), session);
     }
 
+    /// Roll up volume + session counters and emit a `PlatformStats`
+    /// event every `PLATFORM_STATS_EMIT_INTERVAL` settled sessions
+    /// (#200). The counters themselves are always updated so any
+    /// caller can read them via `platform_stats()`; the periodic
+    /// event is for off-chain indexers that prefer push over poll.
+    fn maybe_emit_platform_stats(env: &Env, last_session_volume: i128) {
+        let prev_sessions: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSessionsSettled)
+            .unwrap_or(0u64);
+        let prev_volume: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalVolumeSettled)
+            .unwrap_or(0i128);
+
+        let total_sessions = prev_sessions.saturating_add(1);
+        let total_volume = prev_volume.saturating_add(last_session_volume);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSessionsSettled, &total_sessions);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalVolumeSettled, &total_volume);
+
+        if total_sessions % PLATFORM_STATS_EMIT_INTERVAL == 0 {
+            env.events().publish(
+                (symbol_short!("plat_stat"),),
+                (total_sessions, total_volume, env.ledger().timestamp()),
+            );
+        }
+    }
+
     fn require_participant(session: &Session, caller: &Address) -> Result<(), Error> {
         if *caller != session.seeker && *caller != session.expert {
             return Err(Error::Unauthorized);
@@ -1387,6 +1553,11 @@ impl SkillSphereContract {
             (symbol_short!("session"), symbol_short!("settled")),
             (session_id, expert_payout, now),
         );
+
+        // #200: roll-up volume + session counters and emit a
+        // PlatformStats event every Nth settled session so off-chain
+        // indexers can track growth without re-scanning every event.
+        Self::maybe_emit_platform_stats(env, claimable);
 
         // Increment referral session count for referral commission tracking (Issue #52)
         Self::increment_referral_session_count(env, &expert);
@@ -3676,5 +3847,130 @@ mod test {
         
         assert_eq!(token1_fees, 5); // 5% of 100
         assert_eq!(token2_fees, 5); // 5% of 100
+    }
+
+    // ====================================================================
+    // #198 / #199 / #200 tests
+    // ====================================================================
+
+    #[test]
+    fn test_heartbeat_records_timestamp_and_emits_event() {
+        let (env, client, _, _, _, expert, _, _) = setup();
+        client.register_expert(&expert, &10, &test_cid(&env));
+
+        env.ledger().set_timestamp(2_000);
+        client.heartbeat(&expert);
+        assert_eq!(client.last_heartbeat(&expert), 2_000);
+
+        env.ledger().set_timestamp(2_500);
+        client.heartbeat(&expert);
+        assert_eq!(client.last_heartbeat(&expert), 2_500);
+    }
+
+    #[test]
+    fn test_start_session_succeeds_with_recent_heartbeat() {
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+        env.ledger().set_timestamp(2_000);
+        client.heartbeat(&expert);
+
+        // Inside the 1-hour window — session must start.
+        env.ledger().set_timestamp(2_000 + 30 * 60);
+        let session_id =
+            client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+        assert!(session_id >= 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #34)")]
+    fn test_start_session_fails_when_heartbeat_is_stale() {
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+
+        env.ledger().set_timestamp(2_000);
+        client.heartbeat(&expert);
+
+        // Just past the 1-hour window.
+        env.ledger().set_timestamp(2_000 + 60 * 60 + 1);
+        client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+    }
+
+    #[test]
+    fn test_start_session_legacy_skips_heartbeat_when_never_called() {
+        // Expert never calls heartbeat — backward-compat path: legacy
+        // experts retain availability_status-only semantics.
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+        let session_id =
+            client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+        assert!(session_id >= 1);
+        assert_eq!(client.last_heartbeat(&expert), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #22)")]
+    fn test_heartbeat_rejects_unregistered_expert() {
+        let (env, client, _, _, _, expert, _, _) = setup();
+        let _ = env;
+        client.heartbeat(&expert);
+    }
+
+    #[test]
+    fn test_add_dispute_evidence_replaces_cid_during_active_dispute() {
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+        let session_id =
+            client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+
+        let original = String::from_str(&env, "QmYwAPJzv5CZsnAzt8auVZRnGzrYxkM4Tveoxu48UUfGz1");
+        let updated = String::from_str(&env, "QmYwAPJzv5CZsnAzt8auVZRnGzrYxkM4Tveoxu48UUfGz2");
+        client.flag_dispute(&session_id, &seeker, &String::from_str(&env, "reason"), &original);
+
+        client.add_dispute_evidence(&expert, &session_id, &updated);
+        let dispute = client.get_dispute(&session_id);
+        assert_eq!(dispute.evidence_cid, updated);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn test_add_dispute_evidence_rejects_outsiders() {
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+        let session_id =
+            client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+        client.flag_dispute(
+            &session_id,
+            &seeker,
+            &String::from_str(&env, "reason"),
+            &test_cid(&env),
+        );
+
+        let outsider = Address::generate(&env);
+        client.add_dispute_evidence(
+            &outsider,
+            &session_id,
+            &String::from_str(&env, "QmYwAPJzv5CZsnAzt8auVZRnGzrYxkM4Tveoxu48UUfGz3"),
+        );
+    }
+
+    #[test]
+    fn test_platform_stats_counters_increment_on_settle() {
+        let (env, client, _, _, seeker, expert, token, _) = setup();
+        register_and_avail(&env, &client, &expert, 10);
+
+        let (s0, v0) = client.platform_stats();
+        assert_eq!(s0, 0);
+        assert_eq!(v0, 0);
+
+        let session_id =
+            client.start_session(&seeker, &expert, &token, &3_000, &0, &test_cid(&env));
+        env.ledger().set_timestamp(1_010);
+        let claimable = client.settle_session(&session_id);
+        assert!(claimable > 0);
+
+        let (s1, v1) = client.platform_stats();
+        assert_eq!(s1, 1);
+        // Volume counter tracks gross claimable, not net-of-fee payout.
+        assert!(v1 >= claimable);
     }
 }


### PR DESCRIPTION
## Summary

closes #198
closes #199
closes #200
closes #201

### #199 — Expert Availability "Heartbeat"

- New `heartbeat(expert)` entry point stamps `DataKey::ExpertLastHeartbeat(expert)` with the current ledger timestamp.
- `start_session` rejects with `Error::ExpertOffline` (#34) when `now - last_heartbeat > HEARTBEAT_VALIDITY_WINDOW` (1 hour).
- **Backward-compat:** experts who have never called `heartbeat()` keep the legacy `availability_status`-only semantics so existing flows and the existing test suite keep working.
- `last_heartbeat(expert) -> u64` read accessor.

### #198 — IPFS Evidence Linking for Disputes

- New `add_dispute_evidence(caller, session_id, cid)` updates the active dispute's `evidence_cid` (latest evidence wins).
- Only the seeker, expert, or admin may call; only callable while the dispute is unresolved.
- New `Error::DisputeAlreadyResolved` (#35).
- Emits a `(dispute, evidence)` event so arbitrators get a canonical history of submissions.

### #200 — On-Chain Analytics Events (Volume Tracking)

- `internal_settle` now rolls up `TotalSessionsSettled` and `TotalVolumeSettled` counters and emits a `plat_stat` event every `PLATFORM_STATS_EMIT_INTERVAL` settled sessions (default 100).
- `platform_stats() -> (u64, i128)` read accessor for the running totals.

### #201 — Soroban Gas Sponsorship Integration

- `contracts/GAS_SPONSORSHIP.md` documents how every public entry point is already sponsor-compatible (explicit `Address` invoker + `require_auth`) and walks through a sponsored `start_session` in a TS sketch.
- Audit confirms **no contract-side change is required** — the entry points already match the `pay_and_invoke` sponsorship pattern.

## Test plan

`contracts/src/lib.rs` test module additions cover:

- [x] `heartbeat` records the timestamp and is repeatable.
- [x] `start_session` succeeds when heartbeat is fresh.
- [x] `start_session` panics with `Error(Contract, #34)` when heartbeat is stale (>1h).
- [x] Legacy path: `start_session` still works when an expert has never called heartbeat.
- [x] `heartbeat` rejects unregistered experts with `ExpertNotRegistered` (#22).
- [x] `add_dispute_evidence` replaces the dispute's CID during the active phase.
- [x] `add_dispute_evidence` rejects outsiders with `Unauthorized` (#2).
- [x] `platform_stats` counters increment on `settle_session`.

CI is the source of truth — \`cargo test\` was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expert availability tracking ensures only active experts can be selected for sessions
  * Dispute evidence submission allows participants to add documentation to ongoing disputes
  * Platform statistics now displays total settled sessions and transaction volume

* **Documentation**
  * Added gas sponsorship guide for transaction fee management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LightForgeHub/SkillSphere-Dapp/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->