### PR TITLE
feat: expert tiers, anti-spam deposit, oracle circuit breaker, session expiry

### DIFF
--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -151,4 +151,10 @@ pub mod event_type {
     pub fn badge() -> Symbol {
         symbol_short!("badge")
     }
+    pub fn tier_upgraded() -> Symbol {
+        symbol_short!("tierUp")
+    }
+    pub fn session_expired() -> Symbol {
+        symbol_short!("sessExp")
+    }
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -11,11 +11,15 @@ mod errors;
 mod events;
 mod governance;
 mod reputation;
+mod treasury;
+mod oracles;
+mod scheduling;
 pub use bridge::BridgeError;
 pub use crypto::SessionVoucher;
 pub use dex::SwapPath;
 pub use errors::Error;
 pub use reputation::BadgeRecord;
+pub use reputation::ExpertTier;
 
 use soroban_sdk::{
     contract, contractclient, contractimpl, contracttype, symbol_short, token, xdr::ToXdr, Address,
@@ -49,6 +53,8 @@ const TIMELOCK_DURATION: u64 = 48 * 60 * 60;
 const DISPUTE_EXPIRY_WINDOW: u64 = 30 * 24 * 60 * 60;
 const SESSION_ESCROW_TTL: u64 = 300; // 5 minutes for pause grace period
 const SESSION_NO_SHOW_REFUND_WINDOW: u64 = 600; // 10 minutes
+/// Minimum expiry buffer (2 hours) added to scheduled_start for reserved sessions.
+const SESSION_EXPIRY_BUFFER_SECS: u64 = 2 * 60 * 60;
 pub(crate) const MIN_SESSION_ESCROW: i128 = 10; // Dust cleanup threshold
 const DEFAULT_FEE_FIRST_TIER_LIMIT: i128 = 1_000;
 const DEFAULT_FEE_FIRST_TIER_BPS: u32 = 500;
@@ -96,6 +102,12 @@ pub enum Error {
     InvalidReferrer = 24,
     ReentrancyDetected = 25,
     DepositTooLow = 26,
+    // Anti-spam session deposit
+    InsufficientAntiSpamDeposit = 27,
+    // Oracle circuit breaker
+    CircuitBreakerActive = 28,
+    // Session expiry
+    SessionNotExpired = 29,
 }
 const REFERRAL_COMMISSION_BPS: u32 = 500; // 5% commission of expert earnings paid from platform fee
 const DEFAULT_REFERRAL_SESSION_LIMIT: u32 = 50;
@@ -186,6 +198,15 @@ pub enum DataKey {
     VoucherNonceConsumed(Address, u64),
     ReferralSessionLimit,
     CancellationFeeBps,
+    // Expert tier system
+    ExpertTier(Address),
+    ExpertCompletedSessions(Address),
+    // Anti-spam session deposit
+    SpamDepositAmount,
+    // Oracle circuit breaker
+    LastOraclePrice,
+    CircuitBreakerActive,
+    MaxPriceDeviationBps,
 }
 
 #[contracttype]
@@ -315,6 +336,9 @@ pub struct Session {
     pub agency_share_bps: u32,
     pub rate_currency: RateCurrency,
     pub locked_xlm_rate: Option<i128>,
+    /// Hard expiry timestamp (seconds). Set for Reserved sessions only.
+    /// After this timestamp anyone may call `expire_session` for a full seeker refund.
+    pub expires_at: Option<u64>,
 }
 
 #[contracttype]
@@ -2488,6 +2512,14 @@ impl SkillSphereContract {
         let session_id = Self::next_session_id(env);
         let start_ts = scheduled_start as u32;
 
+        // expires_at = scheduled_start + max(2 hours, duration_cap)
+        let expiry_buffer = if duration_cap > SESSION_EXPIRY_BUFFER_SECS {
+            duration_cap
+        } else {
+            SESSION_EXPIRY_BUFFER_SECS
+        };
+        let expires_at = scheduled_start.saturating_add(expiry_buffer);
+
         let session = Session {
             id: session_id,
             seeker: seeker.clone(),
@@ -2508,6 +2540,7 @@ impl SkillSphereContract {
             agency_share_bps,
             rate_currency,
             locked_xlm_rate,
+            expires_at: Some(expires_at),
         };
 
         env.storage()
@@ -3472,6 +3505,7 @@ impl SkillSphereContract {
             agency_share_bps,
             rate_currency: rate_currency.clone(),
             locked_xlm_rate,
+            expires_at: None,
         };
 
         env.storage()
@@ -3792,7 +3826,13 @@ impl SkillSphereContract {
 
         // #196: per-asset fee override takes priority over the
         // tiered config for this session's funding token.
-        let platform_fee = Self::platform_fee_for_token(env, &session.token, claimable)?;
+        let base_platform_fee = Self::platform_fee_for_token(env, &session.token, claimable)?;
+        // Apply expert-tier discount: Gold = 0 fee, Silver = 50%, Bronze = full.
+        let platform_fee = match reputation::get_tier(env, &session.expert) {
+            ExpertTier::Gold => 0i128,
+            ExpertTier::Silver => base_platform_fee / 2,
+            ExpertTier::Bronze => base_platform_fee,
+        };
         let expert_earnings = claimable.saturating_sub(platform_fee);
         let referrer = Self::expert_referrer(env, &session.expert);
         let referral_reward = if referrer.is_some()
@@ -3834,7 +3874,8 @@ impl SkillSphereContract {
         session.accrued_amount = 0;
         session.last_settlement_timestamp = effective_time as u32;
 
-        if session.balance == 0 || now >= expiry {
+        let session_just_completed = session.balance == 0 || now >= expiry;
+        if session_just_completed {
             session.status = SessionStatus::Completed;
         }
 
@@ -3947,6 +3988,11 @@ impl SkillSphereContract {
             );
         }
 
+        // Recalculate expert tier on session completion.
+        if session_just_completed {
+            reputation::update_expert_tier_on_completion(env, &expert);
+        }
+
         Self::set_reentrancy_lock(env, false);
         Ok(expert_payout)
     }
@@ -4017,6 +4063,9 @@ impl SkillSphereContract {
             session.id,
             (final_claimable, final_remaining, finished_at),
         );
+
+        // Recalculate expert tier whenever a session is explicitly closed.
+        reputation::update_expert_tier_on_completion(env, &session.expert);
 
         Self::set_reentrancy_lock(env, false);
         Ok((final_claimable, final_remaining))
@@ -4420,6 +4469,25 @@ impl SkillSphereContract {
             .persistent()
             .get(&DataKey::ExpertRatingCount(expert))
             .unwrap_or(0)
+    }
+
+    // ====================================================================
+    // Expert Tier System
+    // ====================================================================
+
+    /// Returns the current performance tier of an expert.
+    ///
+    /// Defaults to `ExpertTier::Bronze` for experts with no completed sessions.
+    pub fn get_expert_tier(env: Env, expert: Address) -> ExpertTier {
+        reputation::get_tier(&env, &expert)
+    }
+
+    /// Returns the number of fully-completed sessions for an expert.
+    pub fn get_expert_completed_sessions(env: Env, expert: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExpertCompletedSessions(expert))
+            .unwrap_or(0u32)
     }
 
     /// Registers a new expert with a referrer (Issue #52).
@@ -5256,11 +5324,18 @@ impl SkillSphereContract {
             balance: ask_amount,
             last_settlement_timestamp: now,
             start_timestamp: now,
+            scheduled_start: None,
+            duration_cap: None,
             accrued_amount: 0,
             status: SessionStatus::Active,
             metadata_cid: metadata_cid.clone(),
             encrypted_notes_hash: None,
             paused_at: None,
+            agency_address: profile.agency_address.clone(),
+            agency_share_bps: profile.agency_share_bps,
+            rate_currency: profile.rate_currency.clone(),
+            locked_xlm_rate: None,
+            expires_at: None,
         };
         env.storage()
             .persistent()

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -2717,6 +2717,34 @@ impl SkillSphereContract {
         Ok((refund, fee))
     }
 
+    // ====================================================================
+    // Session Expiry Deadline & Auto-Close
+    // ====================================================================
+
+    /// Force-closes a Reserved (or Paused) session that has passed its
+    /// hard `expires_at` deadline without becoming Active.
+    ///
+    /// Callable by anyone — this is a permissionless safety valve so seekers
+    /// are never permanently locked out of their funds. The full escrow balance
+    /// is refunded to the seeker. Emits `SessionExpired { session_id, refund_amount }`.
+    ///
+    /// # Errors
+    /// * `Error::SessionNotFound`       — session does not exist
+    /// * `Error::InvalidSessionState`   — session has no `expires_at`, is Active, or
+    ///                                    is already in a terminal state
+    /// * `Error::SessionNotExpired`     — `ledger_timestamp < expires_at`
+    pub fn expire_session(env: Env, session_id: u64) -> Result<(), Error> {
+        let session = Self::get_session_or_error(&env, session_id)?;
+        let refund_amount = scheduling::do_expire_session(&env, session)?;
+        events::publish_event(
+            &env,
+            events::event_type::session_expired(),
+            session_id,
+            (session_id, refund_amount),
+        );
+        Ok(())
+    }
+
     fn cancellation_fee_bps(env: &Env) -> u32 {
         env.storage()
             .instance()

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -947,6 +947,34 @@ impl SkillSphereContract {
     }
 
     // ====================================================================
+    // Anti-Spam Session Deposit
+    // ====================================================================
+
+    /// Sets the non-refundable anti-spam deposit required on every new session.
+    ///
+    /// Set to `0` to disable (the default). Deposit is burned to the insurance
+    /// vault on session creation and does not count toward the session escrow.
+    pub fn set_spam_deposit_amount(env: Env, amount: i128) -> Result<(), Error> {
+        Self::require_admin(&env)?;
+        if amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+        treasury::set_spam_deposit_amount(&env, amount);
+        events::publish_event(
+            &env,
+            events::event_type::admin_config(),
+            0,
+            (symbol_short!("spamDep"), amount),
+        );
+        Ok(())
+    }
+
+    /// Returns the currently-configured anti-spam deposit amount.
+    pub fn get_spam_deposit_amount(env: Env) -> i128 {
+        treasury::spam_deposit_amount(&env)
+    }
+
+    // ====================================================================
     // #194 — Fixed-Price Escrow for Milestone Tasks
     // ====================================================================
 
@@ -2389,6 +2417,11 @@ impl SkillSphereContract {
             panic_with_error!(&env, Error::InsufficientBalance);
         }
 
+        // Collect non-refundable anti-spam deposit (burned to insurance vault).
+        if let Err(e) = treasury::collect_spam_deposit(&env, &seeker, &token) {
+            panic_with_error!(&env, e);
+        }
+
         Self::create_active_session(
             &env,
             seeker,
@@ -2465,6 +2498,9 @@ impl SkillSphereContract {
         if token_client.balance(&seeker) < amount {
             return Err(Error::InsufficientBalance);
         }
+
+        // Collect non-refundable anti-spam deposit (burned to insurance vault).
+        treasury::collect_spam_deposit(&env, &seeker, &token)?;
 
         let locked_xlm_rate = if profile.rate_currency == RateCurrency::USD {
             Self::lock_usd_rate_for_session(&env, &expert)

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -2251,6 +2251,53 @@ impl SkillSphereContract {
         Self::protocol_paused(&env)
     }
 
+    // ====================================================================
+    // Oracle Circuit Breaker
+    // ====================================================================
+
+    /// Returns `true` when the oracle circuit breaker is active and new
+    /// sessions are blocked.
+    pub fn is_circuit_breaker_active(env: Env) -> bool {
+        oracles::is_circuit_breaker_active(&env)
+    }
+
+    /// Admin resets the circuit breaker after investigating the price anomaly.
+    pub fn reset_circuit_breaker(env: Env) -> Result<(), Error> {
+        Self::require_admin(&env)?;
+        oracles::reset_circuit_breaker(&env);
+        events::publish_event(
+            &env,
+            events::event_type::admin_config(),
+            0,
+            (symbol_short!("cbReset"),),
+        );
+        Ok(())
+    }
+
+    /// Sets the maximum allowable oracle price deviation in basis points.
+    ///
+    /// Default is 2 000 bps (20%). If the oracle price moves more than this
+    /// fraction in one update, the circuit breaker is tripped.
+    pub fn set_max_price_deviation_bps(env: Env, bps: u32) -> Result<(), Error> {
+        Self::require_admin(&env)?;
+        if bps > MAX_BPS {
+            return Err(Error::InvalidFeeBps);
+        }
+        oracles::set_max_price_deviation_bps(&env, bps);
+        events::publish_event(
+            &env,
+            events::event_type::admin_config(),
+            0,
+            (symbol_short!("maxDevBps"), bps),
+        );
+        Ok(())
+    }
+
+    /// Returns the configured maximum price-deviation threshold in bps.
+    pub fn get_max_price_deviation_bps(env: Env) -> u32 {
+        oracles::max_price_deviation_bps(&env)
+    }
+
     /// Manually sets an expert's reputation (admin only).
     ///
     /// # Arguments
@@ -2378,6 +2425,9 @@ impl SkillSphereContract {
         if Self::protocol_paused(&env) {
             panic_with_error!(&env, Error::ProtocolPaused);
         }
+        if oracles::is_circuit_breaker_active(&env) {
+            panic_with_error!(&env, Error::CircuitBreakerActive);
+        }
         if let Err(e) = admin::rate_limit(&env, &seeker, admin::rate_limit_min_ledgers(&env)) {
             panic_with_error!(&env, e);
         }
@@ -2455,6 +2505,9 @@ impl SkillSphereContract {
     ) -> Result<u64, Error> {
         seeker.require_auth();
         Self::ensure_protocol_active(&env)?;
+        if oracles::is_circuit_breaker_active(&env) {
+            return Err(Error::CircuitBreakerActive);
+        }
         if let Err(e) = admin::rate_limit(&env, &seeker, admin::rate_limit_min_ledgers(&env)) {
             panic_with_error!(&env, e);
         }
@@ -3578,6 +3631,13 @@ impl SkillSphereContract {
         let (price, last_updated_at) = client.get_price(&cfg.asset_pair);
         let now = env.ledger().timestamp() as u32;
         if now.saturating_sub(last_updated_at) > cfg.max_staleness_seconds {
+            return None;
+        }
+
+        // Check price deviation against the last known oracle price.
+        // If deviation exceeds the threshold the circuit breaker activates;
+        // we return None here so the caller falls back to the static rate.
+        if oracles::check_and_update_price(env, price).is_err() {
             return None;
         }
 

--- a/contracts/src/oracles.rs
+++ b/contracts/src/oracles.rs
@@ -1,0 +1,105 @@
+//! Circuit breaker for extreme oracle price movements.
+//!
+//! When the oracle price for the base asset (XLM/USD) changes by more than
+//! `max_price_deviation_bps` basis points in a single update, the contract
+//! activates a circuit breaker that blocks new session creation. This guards
+//! against oracle manipulation attacks where an inflated/deflated price is
+//! injected to drain session escrows.
+//!
+//! ## Storage keys (defined in `lib.rs` DataKey)
+//! - `LastOraclePrice`       — most recently accepted oracle price (Instance storage)
+//! - `CircuitBreakerActive`  — boolean flag; `true` means new sessions are blocked
+//! - `MaxPriceDeviationBps`  — admin-configurable deviation threshold (default 2 000 bps = 20%)
+//!
+//! ## Public functions added to `SkillSphereContract` (in `lib.rs`)
+//! - `set_max_price_deviation_bps(env, bps)` — admin only
+//! - `get_max_price_deviation_bps(env)`      — read the threshold
+//! - `is_circuit_breaker_active(env)`        — check whether the breaker is tripped
+//! - `reset_circuit_breaker(env)`            — admin only; resumes session creation
+
+use soroban_sdk::Env;
+
+use crate::{DataKey, Error};
+
+/// Default maximum allowable price deviation: 20% (2 000 bps).
+pub const DEFAULT_MAX_PRICE_DEVIATION_BPS: u32 = 2_000;
+
+/// Returns `true` if the circuit breaker is currently active (new sessions blocked).
+pub fn is_circuit_breaker_active(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::CircuitBreakerActive)
+        .unwrap_or(false)
+}
+
+/// Deactivates the circuit breaker. Must be called by admin after investigation.
+pub fn reset_circuit_breaker(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CircuitBreakerActive, &false);
+}
+
+/// Returns the configured maximum price-deviation threshold in basis points.
+pub fn max_price_deviation_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MaxPriceDeviationBps)
+        .unwrap_or(DEFAULT_MAX_PRICE_DEVIATION_BPS)
+}
+
+/// Persists a new maximum price-deviation threshold.
+pub fn set_max_price_deviation_bps(env: &Env, bps: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxPriceDeviationBps, &bps);
+}
+
+/// Checks `new_price` against the last stored oracle price and activates the
+/// circuit breaker if the deviation exceeds `max_price_deviation_bps`.
+///
+/// On success the new price is persisted as `LastOraclePrice`. On failure
+/// `Error::CircuitBreakerActive` is returned and the breaker flag is set so
+/// that subsequent calls to `is_circuit_breaker_active` return `true`.
+///
+/// # Deviation formula
+/// ```text
+/// deviation_bps = |new_price - last_price| * 10_000 / last_price
+/// ```
+pub fn check_and_update_price(env: &Env, new_price: i128) -> Result<(), Error> {
+    if new_price <= 0 {
+        // Non-positive prices are ignored — the oracle may not have data yet.
+        return Ok(());
+    }
+
+    if let Some(last_price) = env
+        .storage()
+        .instance()
+        .get::<DataKey, i128>(&DataKey::LastOraclePrice)
+    {
+        if last_price > 0 {
+            let diff = if new_price > last_price {
+                new_price - last_price
+            } else {
+                last_price - new_price
+            };
+            // deviation_bps = |diff| * 10_000 / last_price
+            let deviation_bps = diff.saturating_mul(10_000) / last_price;
+            let max_dev = max_price_deviation_bps(env) as i128;
+
+            if deviation_bps > max_dev {
+                // Trip the circuit breaker.
+                env.storage()
+                    .instance()
+                    .set(&DataKey::CircuitBreakerActive, &true);
+                return Err(Error::CircuitBreakerActive);
+            }
+        }
+    }
+
+    // Price is within bounds — update the stored reference.
+    env.storage()
+        .instance()
+        .set(&DataKey::LastOraclePrice, &new_price);
+
+    Ok(())
+}

--- a/contracts/src/reputation.rs
+++ b/contracts/src/reputation.rs
@@ -1,26 +1,65 @@
 //! # Soulbound Skill Badges — Issue #202
+//! # Expert Tier System
 //!
 //! Rewards experts with a non-transferable (soulbound) badge NFT minted on a
 //! separate SBT contract once they have accumulated ≥ 100 hours of settled
 //! session time inside SkillSphere.
 //!
+//! Expert tier (Bronze / Silver / Gold) is recalculated on every session
+//! completion and stored under `DataKey::ExpertTier(expert)`. Gold experts pay
+//! zero platform fee; Silver experts pay a 50%-discounted fee; Bronze experts
+//! pay the full configured fee.
+//!
 //! ## Storage keys (defined in `lib.rs` DataKey)
-//! - `SbtContractAddress`        — the deployed SBT contract address (admin-set)
-//! - `ExpertBadge(Address)`      — `BadgeRecord` for an expert that has been minted
-//! - `ExpertTotalSeconds(Address)` — running total of settled seconds per expert
+//! - `SbtContractAddress`                  — the deployed SBT contract address
+//! - `ExpertBadge(Address)`                — `BadgeRecord` for a minted expert
+//! - `ExpertTotalSeconds(Address)`         — cumulative settled seconds
+//! - `ExpertTier(Address)`                 — current `ExpertTier` for an expert
+//! - `ExpertCompletedSessions(Address)`    — count of fully-completed sessions
 //!
 //! ## Public functions added to `SkillSphereContract` (in `lib.rs`)
-//! - `set_sbt_contract(env, sbt_addr)`  — admin-only, persists `SbtContractAddress`
-//! - `mint_badge(env, expert)`          — checks threshold, cross-calls SBT contract
-//! - `get_badge(env, expert)`           — reads `ExpertBadge`
-//! - `get_expert_total_seconds(env, expert)` — reads accumulated seconds
+//! - `set_sbt_contract(env, sbt_addr)`           — admin-only
+//! - `mint_badge(env, expert)`                   — checks threshold, cross-calls SBT
+//! - `get_badge(env, expert)`                    — reads `ExpertBadge`
+//! - `get_expert_total_seconds(env, expert)`     — reads accumulated seconds
+//! - `get_expert_tier(env, expert)`              — reads current `ExpertTier`
+//! - `get_expert_completed_sessions(env, expert)` — reads completed session count
 
 #![allow(unused_imports)]
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, IntoVal, Symbol, Vec};
 
+use crate::{DataKey, events};
+
 /// Threshold: 100 hours expressed in seconds.
 pub const BADGE_HOURS_THRESHOLD_SECS: u64 = 100 * 60 * 60;
+
+/// Minimum completed sessions to reach Silver tier.
+pub const TIER_SILVER_MIN_SESSIONS: u32 = 10;
+/// Minimum average rating (1–5 scale) required to reach Silver tier.
+pub const TIER_SILVER_MIN_RATING: u32 = 4;
+/// Minimum completed sessions to reach Gold tier.
+pub const TIER_GOLD_MIN_SESSIONS: u32 = 50;
+/// Minimum average rating (1–5 scale) required to reach Gold tier.
+pub const TIER_GOLD_MIN_RATING: u32 = 4;
+
+/// Expert performance tier that determines platform-fee discounts.
+///
+/// | Tier   | Platform fee         | Conditions                              |
+/// |--------|----------------------|-----------------------------------------|
+/// | Bronze | Full fee (no change) | < 10 sessions OR avg rating < 4         |
+/// | Silver | 50% discount         | ≥ 10 sessions AND avg rating ≥ 4        |
+/// | Gold   | 0% (zero fee)        | ≥ 50 sessions AND avg rating ≥ 4        |
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ExpertTier {
+    /// Default tier — full platform fee applies.
+    Bronze,
+    /// Mid tier — 50% platform-fee discount.
+    Silver,
+    /// Top tier — zero platform fee.
+    Gold,
+}
 
 /// On-chain record stored when a badge is minted for an expert.
 #[contracttype]
@@ -36,16 +75,76 @@ pub struct BadgeRecord {
     pub badge_token_id: u64,
 }
 
-/// Cross-contract call: invokes `mint_badge(expert, badge_id)` on the
-/// external SBT contract.  The SBT contract is expected to implement a
-/// function with the symbol `"mint_bdg"` that accepts an `Address` and
-/// a `u64` badge ID and returns `()`.
+/// Compute the tier an expert belongs to given their performance stats.
 ///
-/// # Arguments
-/// * `env`           — current contract environment
-/// * `sbt_contract`  — address of the deployed SBT contract
-/// * `expert`        — recipient of the soulbound badge
-/// * `badge_id`      — sequential badge token ID (caller supplies)
+/// Tiers escalate from Bronze → Silver → Gold:
+/// - **Gold**: ≥ `TIER_GOLD_MIN_SESSIONS` sessions AND avg rating ≥ `TIER_GOLD_MIN_RATING`
+/// - **Silver**: ≥ `TIER_SILVER_MIN_SESSIONS` sessions AND avg rating ≥ `TIER_SILVER_MIN_RATING`
+/// - **Bronze**: everyone else (including brand-new experts)
+pub fn compute_tier(completed_sessions: u32, avg_rating: u32) -> ExpertTier {
+    if completed_sessions >= TIER_GOLD_MIN_SESSIONS && avg_rating >= TIER_GOLD_MIN_RATING {
+        ExpertTier::Gold
+    } else if completed_sessions >= TIER_SILVER_MIN_SESSIONS
+        && avg_rating >= TIER_SILVER_MIN_RATING
+    {
+        ExpertTier::Silver
+    } else {
+        ExpertTier::Bronze
+    }
+}
+
+/// Reads an expert's current tier from persistent storage (defaults to `Bronze`).
+pub fn get_tier(env: &Env, expert: &Address) -> ExpertTier {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ExpertTier(expert.clone()))
+        .unwrap_or(ExpertTier::Bronze)
+}
+
+/// Called on every session completion.
+///
+/// Increments `ExpertCompletedSessions`, recomputes the tier, persists the
+/// result, and emits a `TierUpgraded` event when the tier level changes.
+pub fn update_expert_tier_on_completion(env: &Env, expert: &Address) {
+    // Increment the completed-session counter for this expert.
+    let prev_count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ExpertCompletedSessions(expert.clone()))
+        .unwrap_or(0u32);
+    let new_count = prev_count.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&DataKey::ExpertCompletedSessions(expert.clone()), &new_count);
+
+    // Average rating — 0 if the expert has no ratings yet (stays Bronze until rated).
+    let avg_rating: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ExpertAverageRating(expert.clone()))
+        .unwrap_or(0u32);
+
+    let old_tier = get_tier(env, expert);
+    let new_tier = compute_tier(new_count, avg_rating);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::ExpertTier(expert.clone()), &new_tier);
+
+    if new_tier != old_tier {
+        // Emit TierUpgraded { expert, old_tier, new_tier }
+        events::publish_event(
+            env,
+            events::event_type::tier_upgraded(),
+            0,
+            (expert.clone(), old_tier, new_tier),
+        );
+    }
+}
+
+/// Cross-contract call: invokes `mint_badge(expert, badge_id)` on the
+/// external SBT contract.  The SBT contract must implement a function with
+/// the symbol `"mint_bdg"` that accepts an `Address` and a `u64` badge ID.
 pub fn cross_contract_mint_badge(
     env: &Env,
     sbt_contract: &Address,

--- a/contracts/src/scheduling.rs
+++ b/contracts/src/scheduling.rs
@@ -1,0 +1,72 @@
+//! Session expiry deadline and auto-close — Task 4.
+//!
+//! Reserved (pending) sessions that are never activated can leave seeker funds
+//! locked indefinitely. Every reserved session is assigned an `expires_at`
+//! hard-deadline set to `scheduled_start + max(2 hours, duration_cap)`.
+//! After this deadline anyone may call `expire_session(session_id)` to trigger
+//! a full refund to the seeker, regardless of whether the expert showed up.
+//!
+//! ## Session struct field
+//! - `expires_at: Option<u64>` — unix timestamp (seconds) after which expiry
+//!   is permissible. `None` for Active sessions that have no hard deadline.
+//!
+//! ## Public function added to `SkillSphereContract` (in `lib.rs`)
+//! - `expire_session(env, session_id)` — callable by anyone; validates expiry
+//!   condition and issues a full seeker refund.
+
+use soroban_sdk::{token, Env};
+
+use crate::{DataKey, Error, Session, SessionStatus};
+
+/// Validates the expiry condition and executes a full seeker refund.
+///
+/// Rules enforced:
+/// 1. `session.expires_at` must be `Some(t)` with `t <= ledger_timestamp`.
+/// 2. Session must NOT be `Active` — only unstarted / still-`Reserved` sessions
+///    (or `Paused` sessions past their deadline) qualify for hard expiry.
+/// 3. Session must not already be `Completed`, `Resolved`, or `CancelledByExpert`.
+///
+/// Returns the refund amount transferred to the seeker on success.
+pub fn do_expire_session(env: &Env, session: Session) -> Result<i128, Error> {
+    let now = env.ledger().timestamp();
+
+    // Validate hard expiry deadline exists and has passed.
+    let expires_at = session.expires_at.ok_or(Error::InvalidSessionState)?;
+    if now < expires_at {
+        return Err(Error::SessionNotExpired);
+    }
+
+    // Active sessions cannot be force-expired; use end_session instead.
+    if session.status == SessionStatus::Active {
+        return Err(Error::InvalidSessionState);
+    }
+
+    // Terminal states — nothing to refund.
+    if matches!(
+        session.status,
+        SessionStatus::Completed | SessionStatus::Resolved | SessionStatus::CancelledByExpert
+    ) {
+        return Err(Error::InvalidSessionState);
+    }
+
+    let refund_amount = session.balance;
+    let session_id = session.id;
+    let seeker = session.seeker.clone();
+    let token_addr = session.token.clone();
+
+    // Mark session as completed and zero the balance.
+    let mut closed = session.clone();
+    closed.balance = 0;
+    closed.status = SessionStatus::Completed;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Session(session_id), &closed);
+
+    // Transfer full balance back to seeker.
+    if refund_amount > 0 {
+        let token_client = token::Client::new(env, &token_addr);
+        token_client.transfer(&env.current_contract_address(), &seeker, &refund_amount);
+    }
+
+    Ok(refund_amount)
+}

--- a/contracts/src/treasury.rs
+++ b/contracts/src/treasury.rs
@@ -1,0 +1,74 @@
+//! Anti-spam session deposit — configurable per-session burn to the insurance fund.
+//!
+//! A small, non-refundable deposit is required when creating any new session.
+//! The deposit is transferred to the contract and credited to the insurance-vault
+//! balance so it cannot be withdrawn by the seeker and acts as a deterrent against
+//! bot-driven session spam.
+//!
+//! ## Storage keys (defined in `lib.rs` DataKey)
+//! - `SpamDepositAmount` — configured deposit per session (i128, default 0 = disabled)
+//!
+//! ## Public functions added to `SkillSphereContract` (in `lib.rs`)
+//! - `set_spam_deposit_amount(env, amount)` — FeeManager / admin only
+//! - `get_spam_deposit_amount(env)` — returns the current deposit requirement
+
+use soroban_sdk::{token, Address, Env};
+
+use crate::{DataKey, Error};
+
+/// Default spam deposit: 0 (disabled until explicitly configured by admin).
+pub const DEFAULT_SPAM_DEPOSIT_AMOUNT: i128 = 0;
+
+/// Returns the currently-configured anti-spam deposit amount.
+pub fn spam_deposit_amount(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::SpamDepositAmount)
+        .unwrap_or(DEFAULT_SPAM_DEPOSIT_AMOUNT)
+}
+
+/// Persists a new anti-spam deposit amount. Callable only by admin.
+pub fn set_spam_deposit_amount(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::SpamDepositAmount, &amount);
+}
+
+/// Collects the anti-spam deposit from `seeker` and credits it to the
+/// insurance vault balance.
+///
+/// If `spam_deposit_amount` is 0 this is a no-op. Returns
+/// `Error::InsufficientAntiSpamDeposit` when the seeker's token balance
+/// cannot cover the deposit. The deposit is separate from the session
+/// escrow and does not count toward `session.balance`.
+pub fn collect_spam_deposit(
+    env: &Env,
+    seeker: &Address,
+    token: &Address,
+) -> Result<(), Error> {
+    let deposit = spam_deposit_amount(env);
+    if deposit == 0 {
+        return Ok(());
+    }
+
+    let token_client = token::Client::new(env, token);
+    if token_client.balance(seeker) < deposit {
+        return Err(Error::InsufficientAntiSpamDeposit);
+    }
+
+    // Transfer deposit into the contract.
+    token_client.transfer(seeker, &env.current_contract_address(), &deposit);
+
+    // Credit to the insurance vault balance (stays in contract until withdrawn).
+    let mut vault_bal: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::InsuranceVaultBalance(token.clone()))
+        .unwrap_or(0i128);
+    vault_bal = vault_bal.saturating_add(deposit);
+    env.storage()
+        .instance()
+        .set(&DataKey::InsuranceVaultBalance(token.clone()), &vault_bal);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Expert Tier System (Bronze / Silver / Gold)**: Adds `ExpertTier` enum to `reputation.rs`. Tier is recalculated on every session completion based on completed-session count and average rating. Gold experts pay 0 platform fee, Silver get a 50% discount, Bronze pay the full fee. Emits `TierUpgraded { expert, old_tier, new_tier }` on tier change. New public functions: `get_expert_tier()`, `get_expert_completed_sessions()`.

- **Anti-Spam Session Deposit Burn**: Creates `treasury.rs`. A configurable `spam_deposit_amount` (default 0 / disabled) is burned to the insurance vault on every `start_session` and `reserve_session` call. Returns `InsufficientAntiSpamDeposit` when the seeker cannot cover the deposit. Admin controls via `set_spam_deposit_amount()`.

- **Oracle Circuit Breaker**: Creates `oracles.rs`. Stores `LastOraclePrice` in Instance storage and computes `|new - last| * 10_000 / last` on every oracle price fetch. If the deviation exceeds `max_price_deviation_bps` (default 20%), `CircuitBreakerActive` is set and new sessions are blocked with `Error::CircuitBreakerActive`. Admin resets with `reset_circuit_breaker()`.

- **Session Expiry Deadline & Auto-Close**: Creates `scheduling.rs` and adds `expires_at: Option<u64>` to `Session`. Reserved sessions get `expires_at = scheduled_start + max(2h, duration_cap)`. Anyone may call `expire_session(session_id)` once the deadline passes and the session is not Active — the full escrow is refunded to the seeker and `SessionExpired { session_id, refund_amount }` is emitted.

## Related Issues
Closes #259 
Closes #260 
Closes #261 
Closes #265 
