### PR TITLE
feat: network mismatch banner, error boundary, mobile nav, expert filters (#298 #302 #303 #367)

### DIFF
--- a/src/app/explore-experts/page.tsx
+++ b/src/app/explore-experts/page.tsx
@@ -8,6 +8,8 @@ import { mockExperts } from '@/utils/data/mock-data';
 export default function ExploreExpertsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [rateFilter, setRateFilter] = useState<string>("all");
+  const [ratingFilter, setRatingFilter] = useState<string>("all");
 
   const categories = Array.from(new Set(mockExperts.map((e) => e.category)));
 
@@ -15,7 +17,21 @@ export default function ExploreExpertsPage() {
     const matchesSearch = expert.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          expert.category.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory = !selectedCategory || expert.category === selectedCategory;
-    return matchesSearch && matchesCategory;
+
+    const numericRate = parseFloat(expert.hourlyRate.replace(/[^0-9.]/g, ""));
+    const matchesRate =
+      rateFilter === "all" ||
+      (rateFilter === "under50" && numericRate < 50) ||
+      (rateFilter === "50to150" && numericRate >= 50 && numericRate <= 150) ||
+      (rateFilter === "over150" && numericRate > 150);
+
+    const matchesRating =
+      ratingFilter === "all" ||
+      (ratingFilter === "4plus" && expert.rating >= 4) ||
+      (ratingFilter === "4.5plus" && expert.rating >= 4.5) ||
+      (ratingFilter === "5" && expert.rating === 5);
+
+    return matchesSearch && matchesCategory && matchesRate && matchesRating;
   });
 
   return (
@@ -78,6 +94,39 @@ export default function ExploreExpertsPage() {
               </button>
             ))}
           </div>
+
+          {/* Rate and Rating Filters */}
+          <div className="flex flex-wrap gap-4">
+            {/* Rate Filter */}
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-gray-400 whitespace-nowrap">Hourly Rate:</label>
+              <select
+                value={rateFilter}
+                onChange={(e) => setRateFilter(e.target.value)}
+                className="bg-gradient-to-r from-purple-600/10 to-pink-600/10 border border-purple-500/30 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500/60 transition-all"
+              >
+                <option value="all">All Rates</option>
+                <option value="under50">Under $50/hr</option>
+                <option value="50to150">$50–$150/hr</option>
+                <option value="over150">Over $150/hr</option>
+              </select>
+            </div>
+
+            {/* Rating Filter */}
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-gray-400 whitespace-nowrap">Rating:</label>
+              <select
+                value={ratingFilter}
+                onChange={(e) => setRatingFilter(e.target.value)}
+                className="bg-gradient-to-r from-purple-600/10 to-pink-600/10 border border-purple-500/30 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-purple-500/60 transition-all"
+              >
+                <option value="all">All Ratings</option>
+                <option value="4plus">4+ Stars</option>
+                <option value="4.5plus">4.5+ Stars</option>
+                <option value="5">5 Stars</option>
+              </select>
+            </div>
+          </div>
         </div>
 
         {/* Results Count */}
@@ -99,6 +148,8 @@ export default function ExploreExpertsPage() {
               onClick={() => {
                 setSearchTerm('');
                 setSelectedCategory(null);
+                setRateFilter('all');
+                setRatingFilter('all');
               }}
               className="px-6 py-2 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 rounded-lg font-semibold transition-all"
             >

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { Home, Compass, LayoutDashboard, Users } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+const BOTTOM_NAV_LINKS = [
+  { href: "/", label: "Home", icon: Home },
+  { href: "/explore", label: "Explore", icon: Compass },
+  { href: "/explore-experts", label: "Experts", icon: Users },
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+];
+
+/** Bottom navigation bar shown on mobile for dashboard routes */
+export default function MobileMenu() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Mobile navigation"
+      className="fixed bottom-0 left-0 right-0 z-40 border-t border-zinc-800/60 bg-zinc-950/95 backdrop-blur-md md:hidden"
+    >
+      <ul className="flex items-stretch">
+        {BOTTOM_NAV_LINKS.map(({ href, label, icon: Icon }) => {
+          const isActive = pathname === href || (href !== "/" && pathname.startsWith(href));
+          return (
+            <li key={href} className="flex-1">
+              <Link
+                href={href}
+                className={`flex flex-col items-center justify-center gap-1 py-3 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "text-violet-400"
+                    : "text-zinc-500 hover:text-zinc-200"
+                }`}
+              >
+                <Icon className="h-5 w-5" />
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -166,8 +166,16 @@ const NAV_LINKS = [
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { address, network } = useWallet();
 
   return (
+    <>
+      {/* Network mismatch alert banner */}
+      {address && network !== null && network !== "TESTNET" && (
+        <div className="w-full bg-red-900/80 border-b border-red-500/50 py-2 px-4 text-center text-sm font-medium text-red-200">
+          Freighter Wallet is set to {network}. Please switch to TESTNET in Freighter extension settings.
+        </div>
+      )}
     <header className="sticky top-0 z-30 border-b border-zinc-800/60 bg-zinc-950/80 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Logo */}
@@ -226,5 +234,6 @@ export default function Navbar() {
         </nav>
       )}
     </header>
+    </>
   );
 }

--- a/src/components/providers/ErrorBoundary.tsx
+++ b/src/components/providers/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[ErrorBoundary] Caught error:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <div
+          role="alert"
+          className="flex min-h-[200px] flex-col items-center justify-center rounded-xl border border-red-500/30 bg-red-500/10 p-8 text-center"
+        >
+          <p className="text-base font-semibold text-red-300">
+            Something went wrong
+          </p>
+          {this.state.error && (
+            <p className="mt-2 text-sm text-red-400/80">
+              {this.state.error.message}
+            </p>
+          )}
+          <button
+            className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-300 transition-colors hover:bg-red-500/20"
+            onClick={() => this.setState({ hasError: false, error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

- **#367**: Add full-width red alert banner in Navbar when Freighter wallet is connected to a non-TESTNET network (e.g. MAINNET/PUBLIC), with exact message per spec
- **#303**: Add reusable `ErrorBoundary` class component (`src/components/providers/ErrorBoundary.tsx`) with optional custom fallback, default red-tinted error UI, and "Try again" reset button
- **#302**: Add `MobileMenu` bottom navigation bar (`src/components/layout/MobileMenu.tsx`) fixed at bottom on mobile with 4 links (Home, Explore, Experts, Dashboard) and active-route highlighting via `usePathname()`
- **#298**: Add hourly rate and rating filter dropdowns to the Expert Discovery page on top of the existing category filter and search

closes #298
closes #302
closes #303
closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile bottom navigation for easier access to Home, Explore, Experts, and Dashboard on smaller screens.
  * Added new filtering options on the experts page for hourly rate and star rating.

* **Bug Fixes**
  * Improved expert filtering so clearing filters now resets all selected criteria.
  * Added a visible warning when a connected wallet is on the wrong network.
  * Added error handling with a friendly recovery screen and retry option if part of the app fails to render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->