### PR TITLE
Expert Busy/In-Session State UI Blockers

### DIFF
--- a/src/app/explore-experts/\[id\]/page.tsx
+++ b/src/app/explore-experts/\[id\]/page.tsx
@@ -72,6 +72,7 @@ export default function ExpertProfilePage({ params }: ExpertProfilePageProps) {
   }
 
   const handleBookClick = () => {
+    if (expert.is_busy) return;
     // Store expert info for the booking flow and navigate to marketplace
     sessionStorage.setItem('selectedExpertId', expert.id);
     sessionStorage.setItem('selectedExpertName', expert.name);

--- a/src/components/marketplace/ExpertCard.tsx
+++ b/src/components/marketplace/ExpertCard.tsx
@@ -48,12 +48,17 @@ export default function ExpertCard({ expert }: ExpertCardProps) {
           {/* Rate and Availability */}
           <div className="flex items-center justify-between mb-4 pb-4 border-b border-purple-500/10">
             <span className="font-bold text-lg text-purple-400">{expert.hourlyRate}</span>
-            {expert.availability && (
+            {expert.is_busy ? (
+              <div className="flex items-center gap-1 px-3 py-1 bg-red-500/20 border border-red-500/50 rounded-full">
+                <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                <span className="text-xs font-medium text-red-400">In Call</span>
+              </div>
+            ) : expert.availability ? (
               <div className="flex items-center gap-1 px-3 py-1 bg-green-500/20 border border-green-500/50 rounded-full">
                 <CheckCircle size={14} className="text-green-400" />
                 <span className="text-xs font-medium text-green-400">Available</span>
               </div>
-            )}
+            ) : null}
           </div>
 
           {/* Response Time */}

--- a/src/components/profile/ExpertDetails.tsx
+++ b/src/components/profile/ExpertDetails.tsx
@@ -36,12 +36,17 @@ export default function ExpertDetails({ expert, onBookClick }: ExpertDetailsProp
                 <Clock size={16} />
                 {expert.responseTime}
               </span>
-              {expert.availability && (
+              {expert.is_busy ? (
+                <span className="px-4 py-2 bg-red-500/20 border border-red-500/50 rounded-full text-sm font-medium flex items-center gap-1">
+                  <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                  In Call
+                </span>
+              ) : expert.availability ? (
                 <span className="px-4 py-2 bg-green-500/20 border border-green-500/50 rounded-full text-sm font-medium flex items-center gap-1">
                   <CheckCircle size={16} />
                   Available Now
                 </span>
-              )}
+              ) : null}
             </div>
 
             {/* Rating */}
@@ -78,12 +83,21 @@ export default function ExpertDetails({ expert, onBookClick }: ExpertDetailsProp
             </div>
 
             {/* Book Button */}
-            <button
-              onClick={onBookClick}
-              className="w-full md:w-auto px-8 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105"
-            >
-              Book Session
-            </button>
+            <div className="relative group">
+              <button
+                onClick={onBookClick}
+                disabled={expert.is_busy}
+                className="w-full md:w-auto px-8 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:from-gray-600 disabled:to-gray-600 disabled:cursor-not-allowed rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 disabled:hover:scale-100"
+              >
+                Book Session
+              </button>
+              {expert.is_busy && (
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-gray-200 text-xs rounded-lg shadow-lg whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                  Expert is currently in another consultation. Please try again later.
+                  <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/utils/data/mock-data.ts
+++ b/utils/data/mock-data.ts
@@ -307,6 +307,7 @@ export const mockExperts: Expert[] = [
         reviews: 127,
         hourlyRate: '$50/hr',
         availability: true,
+        is_busy: false,
         bio: 'Senior Full-Stack Developer with 8+ years of experience in React, Node.js, and cloud technologies. Passionate about mentoring the next generation of developers.',
         skills: ['React', 'Next.js', 'Node.js', 'TypeScript', 'AWS', 'PostgreSQL'],
         responseTime: '< 1 hour',
@@ -348,6 +349,7 @@ export const mockExperts: Expert[] = [
         reviews: 95,
         hourlyRate: '$75/hr',
         availability: true,
+        is_busy: true,
         bio: 'Blockchain architect with 6+ years in smart contract development. Specialized in Stellar, Solana, and EVM chains. DeFi protocol expert.',
         skills: ['Solidity', 'Rust', 'Stellar SDK', 'DeFi', 'Smart Contracts', 'Web3.js'],
         responseTime: '< 30 mins',
@@ -381,6 +383,7 @@ export const mockExperts: Expert[] = [
         reviews: 156,
         hourlyRate: '$60/hr',
         availability: false,
+        is_busy: false,
         bio: 'Creative UI/UX Designer specializing in fintech and Web3 interfaces. Former Design Lead at a top tech startup.',
         skills: ['Figma', 'UI Design', 'UX Research', 'Web3 Design', 'Prototyping', 'Design Systems'],
         responseTime: '< 2 hours',
@@ -406,11 +409,13 @@ export const mockExperts: Expert[] = [
         reviews: 84,
         hourlyRate: '$65/hr',
         availability: true,
+        is_busy: false,
         bio: 'Backend systems engineer with expertise in microservices, APIs, and distributed systems. 5+ years building scalable infrastructure.',
         skills: ['Python', 'Go', 'Kubernetes', 'Docker', 'GraphQL', 'PostgreSQL', 'Redis'],
         responseTime: '< 1 hour',
         totalSessions: 198,
         walletAddress: 'GB3YXVGWVF5MJXGQ3HHHLVXQMIJLYVRQAXDDBJ5FJKPIHSJTQR6SWVBO',
+    },
 ];
 
 export const mockTransactions: Transaction[] = [

--- a/utils/types/types.ts
+++ b/utils/types/types.ts
@@ -61,6 +61,7 @@ export interface Expert {
     reviews: number;
     hourlyRate: string;
     availability: boolean;
+    is_busy?: boolean;
     bio?: string;
     skills?: string[];
     pastReviews?: Review[];


### PR DESCRIPTION
## Summary

Implements #357 - Expert Busy/In-Session State UI Blockers. When an expert is in a live consultation, other seekers are prevented from initiating calls or sending funds.

## Changes

- **utils/types/types.ts**: Added optional `is_busy` field to `Expert` interface
- **utils/data/mock-data.ts**: Added `is_busy` to all mock experts (Alex Kumar set to `true` for demo)
- **src/components/marketplace/ExpertCard.tsx**: Shows animated red dot "In Call" indicator when `is_busy` is true, replacing the green "Available" badge
- **src/components/profile/ExpertDetails.tsx**: Shows "In Call" badge, disables "Book Session" button with gray styling, and renders a tooltip: "Expert is currently in another consultation. Please try again later."
- **src/app/explore-experts/[id]/page.tsx**: Added early return guard in `handleBookClick` if expert is busy

## Verification

- TypeScript compiles without new errors (pre-existing errors in unrelated files)
- Build was already broken pre-existing (unrelated routing issue)
- No test infrastructure exists in the frontend; all existing functionality preserved

Closes #357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added busy/in-call status support for experts across profile cards and detail views.
  * Booking is now blocked when an expert is currently in a consultation, with a clear tooltip message.
* **Bug Fixes**
  * Improved availability display so experts can show “In Call,” “Available,” or no badge based on current status.
  * Updated expert sample data to reflect busy states consistently in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->