### PR TITLE
feat: surge pricing badge and tooltip on ExpertCard rate field

### DIFF
--- a/src/components/marketplace/ExpertCard.tsx
+++ b/src/components/marketplace/ExpertCard.tsx
@@ -2,9 +2,10 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { Star, Clock, CheckCircle } from 'lucide-react';
+import { Star, Clock, CheckCircle, AlertTriangle } from 'lucide-react';
 import { Expert } from '@/utils/types/types';
 import { prefetchExpert } from '@/hooks/useExperts';
+import { useSurgeMultiplier } from '@/hooks/useSurgeMultiplier';
 import { useQueryClient } from '@tanstack/react-query';
 
 interface ExpertCardProps {
@@ -13,10 +14,14 @@ interface ExpertCardProps {
 
 export default function ExpertCard({ expert }: ExpertCardProps) {
   const queryClient = useQueryClient();
+  const { multiplier, isSurgeActive } = useSurgeMultiplier();
 
   const handleMouseEnter = () => {
     prefetchExpert(queryClient, expert.id);
   };
+
+  // Calculate surge percentage for display
+  const surgePercent = Math.round((multiplier - 1) * 100);
 
   return (
     <Link href={`/explore-experts/${expert.id}`}>
@@ -58,7 +63,24 @@ export default function ExpertCard({ expert }: ExpertCardProps) {
 
           {/* Rate and Availability */}
           <div className="flex items-center justify-between mb-4 pb-4 border-b border-purple-500/10">
-            <span className="font-bold text-lg text-purple-400">{expert.hourlyRate}</span>
+            <div className="flex flex-col gap-1">
+              <span
+                className="font-bold text-lg text-purple-400 cursor-help"
+                title="Rate may increase during high demand periods"
+              >
+                {expert.hourlyRate}
+              </span>
+              {isSurgeActive && (
+                <span
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 border border-amber-300 w-fit"
+                  role="alert"
+                  aria-label={`Surge pricing is active. Rate increased by ${surgePercent}%`}
+                >
+                  <AlertTriangle size={12} className="flex-shrink-0" />
+                  Surge Pricing Active (+{surgePercent}%)
+                </span>
+              )}
+            </div>
             {expert.is_busy ? (
               <div className="flex items-center gap-1 px-3 py-1 bg-red-500/20 border border-red-500/50 rounded-full">
                 <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />

--- a/src/hooks/useSurgeMultiplier.ts
+++ b/src/hooks/useSurgeMultiplier.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface UseSurgeMultiplierReturn {
+  multiplier: number;
+  isLoading: boolean;
+  isSurgeActive: boolean;
+  error: string | null;
+}
+
+/**
+ * Reads the current surge multiplier from the contract/oracle.
+ * Returns 1 if surge is inactive or fetch fails.
+ *
+ * Surge multiplier values:
+ * - 100 = 1.0x (no surge)
+ * - 120 = 1.2x (20% surge)
+ * - 150 = 1.5x (50% surge)
+ * etc.
+ */
+export function useSurgeMultiplier(): UseSurgeMultiplierReturn {
+  const [multiplier, setMultiplier] = useState<number>(1);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSurgeMultiplier = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      // TODO: Replace with actual contract read when oracle/contract hook is available
+      // This would typically be:
+      // const multiplierBps = await sorobanClient.readContractState("surge_multiplier");
+      // const actualMultiplier = multiplierBps / 100;
+
+      // For now, fetch from API endpoint (to be replaced with contract read)
+      const res = await fetch("/api/surge-multiplier");
+      
+      if (!res.ok) {
+        throw new Error(`Failed to fetch surge multiplier: ${res.status}`);
+      }
+
+      const data = await res.json();
+      
+      // Assuming API returns { multiplier: 1.2 } or { multiplierBps: 120 }
+      const mult = data.multiplier || data.multiplierBps / 100 || 1;
+      
+      // Ensure multiplier is at least 1
+      setMultiplier(Math.max(1, mult));
+    } catch (err: any) {
+      setError(err.message || "Failed to fetch surge multiplier");
+      // Fail gracefully: default to no surge (multiplier = 1)
+      setMultiplier(1);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSurgeMultiplier();
+
+    // Poll every 30 seconds for surge changes (matches typical blockchain block times)
+    const interval = setInterval(fetchSurgeMultiplier, 30_000);
+
+    return () => clearInterval(interval);
+  }, [fetchSurgeMultiplier]);
+
+  return {
+    multiplier,
+    isLoading,
+    isSurgeActive: multiplier > 1,
+    error,
+  };
+}


### PR DESCRIPTION
## feat: surge pricing badge and tooltip on ExpertCard rate field

Closes #347

---

### Summary

Displays a live warning badge on `ExpertCard` when surge pricing is active. A new `useSurgeMultiplier` hook polls the surge API every 30 seconds and the badge appears automatically when the multiplier exceeds 1x.

---

### Changes

**`src/hooks/useSurgeMultiplier.ts`** — created
- Fetches current surge multiplier from `/api/surge-multiplier`
- Returns `{ multiplier, isLoading, isSurgeActive, error }`
- Polls every 30 seconds to catch live surge changes
- Fails gracefully — defaults to `1x` (no surge) if fetch fails
- Fully typed with `UseSurgeMultiplierReturn` interface
- Ready for contract/oracle integration when backend endpoint is live

**`src/components/marketplace/ExpertCard.tsx`** — modified
- Integrated `useSurgeMultiplier` hook
- Added tooltip on rate field: *"Rate may increase during high demand periods"*
- Added amber warning badge when `isSurgeActive`:
  - Text: `⚠️ Surge Pricing Active (+X%)`
  - Percentage calculated as `Math.round((multiplier - 1) * 100)`
  - Light mode: `bg-amber-100 text-amber-800 border-amber-300`
  - Dark mode: `bg-amber-900 text-amber-200`
  - `role="alert"` + `aria-label` with percentage for screen readers
  - `AlertTriangle` icon for visual emphasis
- Mobile layout preserved with `flex flex-col gap-1`
- No breaking changes to existing card structure

---

### Badge Preview

```
$120/hr  ⚠️ Surge Pricing Active (+20%)
         "Rate may increase during high demand periods"
```

---

### Security Notes

- Hook fails closed: on fetch error, multiplier defaults to `1` — badge never shows a false surge alert
- No contract address or sensitive config exposed in component
- Polling uses cleanup on unmount — no memory leaks

---

### Note

The `/api/surge-multiplier` backend endpoint is stubbed and ready for contract/oracle integration. The hook will read live values automatically once the endpoint is wired to the on-chain oracle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added surge-pricing indicators to expert cards, showing when higher rates are active.
  * Expert rate displays now include a clear badge with accessible alert messaging when surge pricing applies.
  * Added live polling support so surge pricing status updates automatically over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->