### PR TITLE
feat(marketplace): add TokenSwapWidget with live XLM to USDC DEX rates

### DIFF
--- a/src/components/marketplace/TokenSwapWidget.tsx
+++ b/src/components/marketplace/TokenSwapWidget.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, RefreshCw, AlertTriangle } from "lucide-react";
+import { useWallet } from "@/providers/WalletProvider";
+import {
+  XLM,
+  USDC,
+  getSwapQuote,
+  getReferenceRate,
+  type SwapQuote,
+} from "@/lib/dexService";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Minimum native XLM kept aside for Stellar transaction fees (matches FundSessionModal). */
+const MIN_XLM_FOR_FEES = 1;
+/** Debounce window for re-fetching a quote after the user stops typing. */
+const QUOTE_DEBOUNCE_MS = 400;
+/** How often the reference rate refreshes in the background. */
+const RATE_REFRESH_MS = 30_000;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface TokenSwapWidgetProps {
+  /** Pre-fill the XLM "You Pay" field, e.g. with a session cost. */
+  initialAmount?: number;
+  /**
+   * Click handler for the swap action. The widget only fetches live rates and
+   * surfaces the estimated USDC out; actual on-chain swap execution is delegated
+   * to the parent (e.g. the checkout flow) so this layer stays network-agnostic.
+   */
+  onSwap?: (xlmAmount: number, usdcEstimate: number) => void | Promise<void>;
+  /** Disables the swap action (e.g. while a parent transaction is in flight). */
+  isSwapping?: boolean;
+  className?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function TokenSwapWidget({
+  initialAmount,
+  onSwap,
+  isSwapping = false,
+  className,
+}: TokenSwapWidgetProps) {
+  const { address, balance, isLoading: walletLoading } = useWallet();
+
+  const [xlmInput, setXlmInput] = useState<string>(
+    initialAmount ? initialAmount.toString() : "",
+  );
+  const [quote, setQuote] = useState<SwapQuote | null>(null);
+  const [referenceRate, setReferenceRate] = useState<number | null>(null);
+  const [isFetchingQuote, setIsFetchingQuote] = useState(false);
+  const [isRefreshingRate, setIsRefreshingRate] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Reference rate (background refresh) ─────────────────────────────────────
+
+  const refreshReferenceRate = useCallback(async (silent = false) => {
+    if (!silent) setIsRefreshingRate(true);
+    try {
+      const rate = await getReferenceRate(XLM, USDC);
+      if (rate !== null) setReferenceRate(rate);
+    } catch {
+      // Leave stale rate in place so the UI stays functional
+    } finally {
+      if (!silent) setIsRefreshingRate(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshReferenceRate();
+    const id = setInterval(() => refreshReferenceRate(true), RATE_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [refreshReferenceRate]);
+
+  // ── Exact quote for the entered amount (debounced) ───────────────────────────
+
+  const xlmAmount = useMemo(() => {
+    const n = parseFloat(xlmInput);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  }, [xlmInput]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (xlmAmount <= 0) {
+      setQuote(null);
+      setError(null);
+      return;
+    }
+
+    setIsFetchingQuote(true);
+    setError(null);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const q = await getSwapQuote(XLM, USDC, xlmAmount);
+        setQuote(q);
+        if (!q) setError("No swap path available for this amount");
+      } catch {
+        setError("Failed to fetch live swap rate");
+        setQuote(null);
+      } finally {
+        setIsFetchingQuote(false);
+      }
+    }, QUOTE_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [xlmAmount]);
+
+  // ── Derived state ───────────────────────────────────────────────────────────
+
+  const walletBalance = balance !== null ? parseFloat(balance) : null;
+  const balanceUnavailable =
+    walletLoading || !address || walletBalance === null || Number.isNaN(walletBalance);
+  const insufficientBalance =
+    !balanceUnavailable && walletBalance !== null && walletBalance < xlmAmount + MIN_XLM_FOR_FEES;
+
+  const usdcEstimate = quote?.destinationAmount ?? 0;
+  const effectiveRate = quote?.rate ?? referenceRate;
+
+  const canSwap =
+    !isSwapping &&
+    !isFetchingQuote &&
+    xlmAmount > 0 &&
+    quote !== null &&
+    !balanceUnavailable &&
+    !insufficientBalance;
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  const handleMax = () => {
+    if (balanceUnavailable || walletBalance === null) return;
+    const max = Math.max(0, walletBalance - MIN_XLM_FOR_FEES);
+    setXlmInput(max > 0 ? max.toFixed(7).replace(/\.?0+$/, "") : "0");
+  };
+
+  const handleSwap = async () => {
+    if (!canSwap || !quote) return;
+    await onSwap?.(xlmAmount, quote.destinationAmount);
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      className={`bg-gradient-to-br from-purple-600/20 to-pink-600/20 border border-purple-500/30 rounded-2xl p-5 space-y-4 ${className ?? ""}`}
+    >
+      {/* Header / live rate */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-200">Swap XLM → USDC</h3>
+        <button
+          type="button"
+          onClick={() => refreshReferenceRate()}
+          disabled={isRefreshingRate}
+          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-purple-300 transition-colors disabled:opacity-50"
+          title="Refresh live rate"
+        >
+          <RefreshCw size={12} className={isRefreshingRate ? "animate-spin" : ""} />
+          {effectiveRate
+            ? `1 XLM ≈ ${effectiveRate.toFixed(4)} USDC`
+            : "Fetching rate…"}
+        </button>
+      </div>
+
+      {/* You Pay (XLM) */}
+      <div className="bg-purple-600/10 border border-purple-500/20 rounded-xl p-3 space-y-2">
+        <div className="flex items-center justify-between text-xs text-gray-400">
+          <span>You Pay</span>
+          <button
+            type="button"
+            onClick={handleMax}
+            disabled={balanceUnavailable}
+            className="text-purple-300 hover:text-purple-200 disabled:opacity-50 transition-colors"
+          >
+            Max
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min="0"
+            step="any"
+            inputMode="decimal"
+            placeholder="0.0"
+            value={xlmInput}
+            onChange={(e) => setXlmInput(e.target.value)}
+            className="flex-1 bg-transparent text-2xl font-semibold outline-none placeholder:text-gray-600 w-full"
+          />
+          <span className="shrink-0 text-sm font-semibold text-gray-200 bg-purple-600/20 px-2 py-1 rounded-md">
+            XLM
+          </span>
+        </div>
+        {!balanceUnavailable && walletBalance !== null && (
+          <p className="text-xs text-gray-500">
+            Balance: {walletBalance.toFixed(2)} XLM
+          </p>
+        )}
+        {balanceUnavailable && address && (
+          <p className="text-xs text-gray-500">Balance unavailable</p>
+        )}
+      </div>
+
+      {/* Direction indicator */}
+      <div className="flex justify-center -my-2">
+        <div className="bg-purple-500/20 border border-purple-500/40 rounded-full p-1.5">
+          <ArrowDown size={14} className="text-purple-300" />
+        </div>
+      </div>
+
+      {/* You Receive (USDC estimate) */}
+      <div className="bg-purple-600/10 border border-purple-500/20 rounded-xl p-3 space-y-2">
+        <div className="flex items-center justify-between text-xs text-gray-400">
+          <span>You Receive (estimated)</span>
+          {isFetchingQuote && (
+            <span className="text-purple-300 animate-pulse">fetching…</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="flex-1 text-2xl font-semibold text-gray-100">
+            {usdcEstimate > 0 ? usdcEstimate.toFixed(4) : "0.0"}
+          </span>
+          <span className="shrink-0 text-sm font-semibold text-gray-200 bg-purple-600/20 px-2 py-1 rounded-md">
+            USDC
+          </span>
+        </div>
+      </div>
+
+      {/* Inline error */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3"
+        >
+          <AlertTriangle size={16} className="text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-200">{error}</p>
+        </div>
+      )}
+
+      {/* Insufficient balance warning */}
+      {insufficientBalance && walletBalance !== null && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3"
+        >
+          <AlertTriangle size={16} className="text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-200">
+            Insufficient XLM (keep {MIN_XLM_FOR_FEES} XLM for fees)
+          </p>
+        </div>
+      )}
+
+      {/* Swap action */}
+      <button
+        type="button"
+        onClick={handleSwap}
+        disabled={!canSwap}
+        className="w-full px-4 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:from-purple-600/50 disabled:to-pink-600/50 rounded-lg font-semibold transition-all disabled:cursor-not-allowed flex items-center justify-center gap-2"
+      >
+        {isSwapping
+          ? "Swapping…"
+          : !address
+            ? "Connect wallet to swap"
+            : insufficientBalance
+              ? "Insufficient balance"
+              : "Swap XLM → USDC"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/dexService.ts
+++ b/src/lib/dexService.ts
@@ -1,0 +1,153 @@
+// DEX service: live Stellar DEX swap-rate fetching for XLM ⇄ USDC
+// used by the checkout swap widget before funding a session.
+//
+// Rates come from Horizon's `/paths/strict-send` endpoint, which queries
+// live on-chain order books — no external price oracle is involved.
+
+// ─── Assets ───────────────────────────────────────────────────────────────────
+
+export interface StellarAsset {
+  code: string;
+  // null for the network-native asset (XLM); otherwise the issuing account key
+  issuer: string | null;
+}
+
+/** Stellar lumens — network-native, no issuer */
+export const XLM: StellarAsset = { code: "XLM", issuer: null };
+
+/**
+ * Circle-issued USDC on Stellar mainnet. We intentionally target the canonical
+ * Centre issuer (no bridge variant) per the integration spec.
+ */
+export const USDC: StellarAsset = {
+  code: "USDC",
+  issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+};
+
+// ─── Horizon ──────────────────────────────────────────────────────────────────
+
+// Per integration direction: rate fetches use mainnet regardless of the
+// wallet's connected network, since we only display live prices and never
+// post swaps to a network-specific USDC issuer from this layer.
+const HORIZON_URL = "https://horizon.stellar.org";
+
+// Matches the on-chain DEX contract default in contracts/src/dex.rs.
+// Kept here as a configurable constant but not surfaced in the widget UI.
+export const DEFAULT_MAX_SLIPPAGE_BPS = 50;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PathHop {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+export interface SwapPath {
+  source_amount: string;
+  destination_amount: string;
+  destination_asset_code: string;
+  destination_asset_issuer: string;
+  path: PathHop[];
+}
+
+export interface SwapQuote {
+  sourceAmount: number;
+  destinationAmount: number;
+  // destination units per 1 unit of source
+  rate: number;
+  path: SwapPath;
+}
+
+// ─── Horizon query helpers ────────────────────────────────────────────────────
+
+function assetParams(asset: StellarAsset, role: "source" | "destination"): URLSearchParams {
+  const params = new URLSearchParams();
+  if (asset.issuer === null) {
+    params.set(`${role}_asset_type`, "native");
+  } else {
+    params.set(`${role}_asset_type`, "credit_alphanum4");
+    params.set(`${role}_asset_code`, asset.code);
+    params.set(`${role}_asset_issuer`, asset.issuer);
+  }
+  return params;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Query Horizon `/paths/strict-send` for live swap paths from `source` → `dest`
+ * given a fixed source amount. Returns paths sorted best-rate-last by Horizon;
+ * caller should re-select the best via `getBestPath`.
+ */
+export async function fetchSwapPaths(
+  source: StellarAsset,
+  dest: StellarAsset,
+  sourceAmount: number,
+): Promise<SwapPath[]> {
+  if (!Number.isFinite(sourceAmount) || sourceAmount <= 0) return [];
+
+  const params = new URLSearchParams();
+  params.set("source_amount", sourceAmount.toFixed(7));
+  for (const [k, v] of assetParams(source, "source")) params.set(k, v);
+  for (const [k, v] of assetParams(dest, "destination")) params.set(k, v);
+
+  const res = await fetch(`${HORIZON_URL}/paths/strict-send?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Horizon responded with ${res.status}`);
+  }
+  const data = (await res.json()) as {
+    _embedded?: { records?: SwapPath[] };
+  };
+  return data._embedded?.records ?? [];
+}
+
+/**
+ * Pick the path delivering the highest destination amount (best rate for the user).
+ */
+export function getBestPath(paths: SwapPath[]): SwapPath | null {
+  if (paths.length === 0) return null;
+  return paths.reduce((best, current) =>
+    parseFloat(current.destination_amount) > parseFloat(best.destination_amount)
+      ? current
+      : best,
+  );
+}
+
+/**
+ * Build a full quote (estimated output + rate) for a `source` → `dest` swap.
+ * Returns null if no path is currently available for the requested amount.
+ */
+export async function getSwapQuote(
+  source: StellarAsset,
+  dest: StellarAsset,
+  sourceAmount: number,
+): Promise<SwapQuote | null> {
+  const paths = await fetchSwapPaths(source, dest, sourceAmount);
+  const best = getBestPath(paths);
+  if (!best) return null;
+
+  const src = parseFloat(best.source_amount);
+  const dst = parseFloat(best.destination_amount);
+  if (!Number.isFinite(src) || src <= 0) return null;
+
+  return {
+    sourceAmount: src,
+    destinationAmount: dst,
+    rate: dst / src,
+    path: best,
+  };
+}
+
+/**
+ * Reference rate (destination per 1 unit of source) for display purposes.
+ * Uses a meaningful reference amount to keep the queried order book deep.
+ */
+export async function getReferenceRate(
+  source: StellarAsset,
+  dest: StellarAsset,
+  referenceAmount = 100,
+): Promise<number | null> {
+  const quote = await getSwapQuote(source, dest, referenceAmount);
+  return quote?.rate ?? null;
+}


### PR DESCRIPTION
Closes #311 

@Luluameh 

Adds a swap widget that fetches live XLM/USDC rates from Stellar Horizon /paths/strict-send and surfaces an estimated USDC output before funding. Network-agnostic: actual on-chain swap execution is delegated to the parent checkout flow via an onSwap callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new token swap interface for exchanging XLM to USDC with live rate updates, estimated output, balance checks, and a one-tap “Max” option.
  * Introduced real-time swap quoting so users can see updated pricing before confirming a trade.

* **Bug Fixes**
  * Improved handling for invalid or zero swap amounts by clearing quotes and warnings automatically.
  * Added clearer warnings when available balance is too low to cover a swap and network fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->